### PR TITLE
fix(spring-testing): avoid link conflict with general testing chapter

### DIFF
--- a/site/src/documents/guides/user-guide/chapters/04-spring-framework-integration/06-testing.html.md
+++ b/site/src/documents/guides/user-guide/chapters/04-spring-framework-integration/06-testing.html.md
@@ -1,6 +1,6 @@
 ---
 
-title: 'Testing'
+title: 'Spring-based Testing'
 category: 'Spring Framework Integration'
 
 ---


### PR DESCRIPTION
The title of the Spring testing section produces: <section id="testing"> which is
targeted by links that point to the general testing chapter
