### PR TITLE
feat(single-page): Add everything to single page documentation

### DIFF
--- a/site/src/documents/single-page.html
+++ b/site/src/documents/single-page.html
@@ -34,4 +34,15 @@ chapters:
     - title: 'Deployment Descriptors'
       part: 'api-references/deployment-descriptors'
 
+    - title: 'Examples'
+      part: 'real-life/examples'
+
+    - title: 'Tutorials & How-tos'
+      part: 'real-life/how-to'
+
+    - title: 'Incubation'
+      part: 'incubation'
+
+    - title: 'Enterprise'
+      part: 'enterprise'
 ---


### PR DESCRIPTION
This adds the sections real life, incubation and enterprise to the single page version of docs.camunda.org

Unfortunately, examples and incubation appear empty in the single page and I couldn't figure out why. Could you please fix this before merging?
