### PR TITLE
fix(Doc) Hint to Maven Nexus Server for Download WARs

### DIFF
--- a/site/src/documents/guides/installation-guide/glassfish/chapters/02-web-applications/01-install-rest.html.md
+++ b/site/src/documents/guides/installation-guide/glassfish/chapters/02-web-applications/01-install-rest.html.md
@@ -13,7 +13,8 @@ See the above section on how to [install the pre-built distro](ref:#bpm-platform
 
 The following steps are required to deploy the REST API on a Glassfish instance:
 
-1. Download the REST API web application archive from our [server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/camunda-engine-rest/).
+1. Download the REST API web application archive from our [Maven Nexus Server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/camunda-engine-rest/).
+   Or switch to the private repository for the enterprise version (User and password from license required).
    Choose the correct version named `$PLATFORM_VERSION/camunda-engine-rest-$PLATFORM_VERSION.war`.
 2. Optionally, you may change the context path to which the REST API will be deployed (default is `/engine-rest`).
    Edit the file `WEB-INF/sun-web.xml` in the war file and update the `context-root` element accordingly.

--- a/site/src/documents/guides/installation-guide/glassfish/chapters/02-web-applications/02-install-cycle.html.md
+++ b/site/src/documents/guides/installation-guide/glassfish/chapters/02-web-applications/02-install-cycle.html.md
@@ -70,7 +70,8 @@ To exchange the preconfigured H2 datasource with your own, e.g. Oracle, you have
 
 ## Install camunda Cycle on vanilla GlassFish
 
-You can download the camunda Cycle web application from our [server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/cycle/camunda-cycle-glassfish/).
+You can download the camunda Cycle web application from our [Maven Nexus Server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/cycle/camunda-cycle-glassfish/).
+Or switch to the private repository for the enterprise version (User and password from license required).
 Choose the correct version named `$PLATFORM_VERSION/camunda-cycle-glassfish-$PLATFORM_VERSION.war`.
 
 ### Create a datasource

--- a/site/src/documents/guides/installation-guide/glassfish/chapters/02-web-applications/03-install-cockpit-tasklist.html.md
+++ b/site/src/documents/guides/installation-guide/glassfish/chapters/02-web-applications/03-install-cockpit-tasklist.html.md
@@ -12,7 +12,8 @@ See the above section on how to [install the pre-built distro](ref:#bpm-platform
 
 The following steps are required to deploy the applications on a Glassfish instance:
 
-1. Download the camunda web application that contains both applications from our [server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/webapp/camunda-webapp-glassfish/).
+1. Download the camunda web application that contains both applications from our [Maven Nexus Server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/webapp/camunda-webapp-glassfish/).
+   Or switch to the private repository for the enterprise version (User and password from license required).
    Choose the correct version named `$PLATFORM_VERSION/camunda-webapp-glassfish-$PLATFORM_VERSION.war`.
 2. Optionally, you may change the context path to which the application will be deployed (default is `/camunda`).
    Edit the file `WEB-INF/sun-web.xml` in the war file and update the `context-root` element accordingly.

--- a/site/src/documents/guides/installation-guide/jboss/chapters/02-web-applications/01-install-rest.html.md
+++ b/site/src/documents/guides/installation-guide/jboss/chapters/02-web-applications/01-install-rest.html.md
@@ -13,7 +13,8 @@ See the above section on how to [install the pre-built distro](ref:#bpm-platform
 
 The following steps are required to deploy the REST API on a JBoss instance:
 
-1. Download the REST API web application archive from our [server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/camunda-engine-rest/).
+1. Download the REST API web application archive from our [Maven Nexus Server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/camunda-engine-rest/).
+   Or switch to the private repository for the enterprise version (User and password from license required).
    Choose the correct version named `$PLATFORM_VERSION/camunda-engine-rest-$PLATFORM_VERSION.war`.
 2. Optionally, you may change the context path to which the REST API will be deployed (default is `/engine-rest`).
    Edit the file `WEB-INF/jboss-web.xml` in the war file and update the `context-root` element accordingly.

--- a/site/src/documents/guides/installation-guide/jboss/chapters/02-web-applications/02-install-cycle.html.md
+++ b/site/src/documents/guides/installation-guide/jboss/chapters/02-web-applications/02-install-cycle.html.md
@@ -54,7 +54,8 @@ To exchange the preconfigured H2 database with your own, e.g. Oracle, you have t
 
 ## Install camunda Cycle on vanilla JBoss AS 7
 
-You can download the camunda Cycle web application from our [server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/cycle/camunda-cycle-jboss/).
+You can download the camunda Cycle web application from our [Maven Nexus Server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/cycle/camunda-cycle-jboss/).
+Or switch to the private repository for the enterprise version (User and password from license required).
 Choose the correct version named `$PLATFORM_VERSION/camunda-cycle-jboss-$PLATFORM_VERSION.war`.
 
 ### Create a datasource

--- a/site/src/documents/guides/installation-guide/jboss/chapters/02-web-applications/03-install-cockpit-tasklist.html.md
+++ b/site/src/documents/guides/installation-guide/jboss/chapters/02-web-applications/03-install-cockpit-tasklist.html.md
@@ -13,7 +13,8 @@ See the above section on how to [install the pre-built distro](ref:#bpm-platform
 
 The following steps are required to deploy the applications on a JBoss instance:
 
-1.  Download the camunda web application that contains both applications from our [server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/webapp/camunda-webapp-jboss/).
+1.  Download the camunda web application that contains both applications from our [Maven Nexus Server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/webapp/camunda-webapp-jboss/).
+    Or switch to the private repository for the enterprise version (User and password from license required).
     Choose the correct version named `$PLATFORM_VERSION/camunda-webapp-jboss-$PLATFORM_VERSION.war`.
 2.  Optionally, you may change the context path to which the application will be deployed (default is `/camunda`).
     Edit the file `WEB-INF/jboss-web.xml` in the war file and update the `context-root` element accordingly.

--- a/site/src/documents/guides/installation-guide/tomcat/chapters/02-web-applications/01-install-rest.html.md
+++ b/site/src/documents/guides/installation-guide/tomcat/chapters/02-web-applications/01-install-rest.html.md
@@ -14,7 +14,8 @@ See the above section on how to [install the pre-built distro](ref:#bpm-platform
 
 The following steps are required to deploy the REST API on a Tomcat instance:
 
-1.  Download the REST API web application archive from our [server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/camunda-engine-rest/).
+1.  Download the REST API web application archive from our [Maven Nexus Server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/camunda-engine-rest/).
+    Or switch to the private repository for the enterprise version (User and password from license required).
     Choose the correct version named `$PLATFORM_VERSION/camunda-engine-rest-$PLATFORM_VERSION-tomcat.war`.
 2.  Copy the war file to `$CATALINA_HOME/webapps`.
    Optionally you may rename it or extract it to a folder to deploy it to a specific context like `/engine-rest`.

--- a/site/src/documents/guides/installation-guide/tomcat/chapters/02-web-applications/02-install-cycle.html.md
+++ b/site/src/documents/guides/installation-guide/tomcat/chapters/02-web-applications/02-install-cycle.html.md
@@ -52,7 +52,8 @@ To exchange the preconfigured H2 database with your own, e.g. Oracle, you have t
 
 ## Install camunda Cycle on vanilla Tomcat 7
 
-You can download the camunda Cycle web application from our [server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/cycle/camunda-cycle-tomcat/).
+You can download the camunda Cycle web application from our [Maven Nexus Server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/cycle/camunda-cycle-tomcat/).
+Or switch to the private repository for the enterprise version (User and password from license required).
 Choose the correct version named `$PLATFORM_VERSION/camunda-cycle-tomcat-$PLATFORM_VERSION.war`.
 
 ### Create a datasource

--- a/site/src/documents/guides/installation-guide/tomcat/chapters/02-web-applications/03-install-cockpit-tasklist.html.md
+++ b/site/src/documents/guides/installation-guide/tomcat/chapters/02-web-applications/03-install-cockpit-tasklist.html.md
@@ -12,7 +12,8 @@ See the above section on how to [install the pre-built distro](ref:#bpm-platform
 
 The following steps are required to deploy the applications on a Tomcat instance:
 
-1. Download the camunda web application that contains both applications from our [server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/webapp/camunda-webapp-tomcat/).
+1. Download the camunda web application that contains both applications from our [Maven Nexus Server](https://app.camunda.com/nexus/content/groups/public/org/camunda/bpm/webapp/camunda-webapp-tomcat/).
+   Or switch to the private repository for the enterprise version (User and password from license required).
    Choose the correct version named `$PLATFORM_VERSION/camunda-webapp-tomcat-$PLATFORM_VERSION.war`.
 2. Copy the war file to `$CATALINA_HOME/webapps/camunda.war`.
    Optionally you may name it differently or extract it to a folder to deploy it to a different context path.


### PR DESCRIPTION
Better docs, now the difference between camunda.org/download and the Maven Nexus Server is clear.
