### PR TITLE
chore(rest) add activityId to Job query GET and POST, and Job count GET and POST

### DIFF
--- a/site/src/documents/api-references/rest/job/get-query-count.html.md
+++ b/site/src/documents/api-references/rest/job/get-query-count.html.md
@@ -49,6 +49,10 @@ Parameters
     <td>Filter by the key of the process definition the jobs run on.</td>
   </tr>   
   <tr>
+	<td>activityId</td>
+	<td>Only select jobs which exist for the given activity id.</td>
+  </tr>
+  <tr>
     <td>withRetriesLeft</td>
     <td>Only select jobs which have retries left.</td>
   </tr>

--- a/site/src/documents/api-references/rest/job/get-query.html.md
+++ b/site/src/documents/api-references/rest/job/get-query.html.md
@@ -49,6 +49,10 @@ Parameters
     <td>Filter by the key of the process definition the jobs run on.</td>
   </tr>    
   <tr>
+	<td>activityId</td>
+	<td>Only select jobs which exist for the given activity id.</td>
+  </tr>
+  <tr>
     <td>withRetriesLeft</td>
     <td>Only select jobs which have retries left.</td>
   </tr>

--- a/site/src/documents/api-references/rest/job/post-query-count.html.md
+++ b/site/src/documents/api-references/rest/job/post-query-count.html.md
@@ -50,6 +50,10 @@ A JSON object with the following properties:
     <td>Filter by the key of the process definition the jobs run on.</td>
   </tr>   
   <tr>
+	<td>activityId</td>
+	<td>Only select jobs which exist for the given activity id.</td>
+  </tr>
+  <tr>
     <td>withRetriesLeft</td>
     <td>Only select jobs which have retries left. Valid value is a <code>boolean</code>.</td>
   </tr>

--- a/site/src/documents/api-references/rest/job/post-query.html.md
+++ b/site/src/documents/api-references/rest/job/post-query.html.md
@@ -67,6 +67,10 @@ A JSON object with the following properties:
     <td>Filter by the key of the process definition the jobs run on.</td>
   </tr>   
   <tr>
+	<td>activityId</td>
+	<td>Only select jobs which exist for the given activity id.</td>
+  </tr>
+  <tr>
     <td>withRetriesLeft</td>
     <td>Only select jobs which have retries left. Valid value is a <code>boolean</code>.</td>
   </tr>


### PR DESCRIPTION
This is a pull request that adds the documentation for the activity Id that has been exposed in the REST API
