### PR TITLE
Using historyService instead of runtimeService

### DIFF
--- a/content/user-guide/process-engine/history.md
+++ b/content/user-guide/process-engine/history.md
@@ -302,7 +302,7 @@ The user operation log contains entries for many API operations and can be used 
 
 ## Access the User Operation Log
 
-The user operation log can be accessed via the Java API. The runtime service can be used to execute a `UserOperationLogQuery` by calling `runtimeService.createUserOperationLogQuery().execute()`. The query can be restricted with various filtering options. The query is also [exposed in the REST API]({{< relref "reference/rest/history/user-operation-log/get-user-operation-log-query.md" >}}).
+The user operation log can be accessed via the Java API. The history service can be used to execute a `UserOperationLogQuery` by calling `historyService.createUserOperationLogQuery().execute()`. The query can be restricted with various filtering options. The query is also [exposed in the REST API]({{< relref "reference/rest/history/user-operation-log/get-user-operation-log-query.md" >}}).
 
 
 ## User Operation Log Entries


### PR DESCRIPTION
When I was reading the docs, it was a bit confusing, so because of that here is the pull request that fixes this documentation issue (also because the method doesn't exist on runtimeService but it does on historyService).