### PR TITLE
Adding org.jboss.as.threads extesion if not already exists.

### DIFF
--- a/content/installation/full/jboss/manual.md
+++ b/content/installation/full/jboss/manual.md
@@ -159,6 +159,8 @@ Add the Camunda subsystem as extension:
   <extensions>
     ...
     <extension module="org.camunda.bpm.wildfly.camunda-wildfly-subsystem"/>
+    <!-- Add below extension if not already exists -->
+    <extension module="org.jboss.as.threads"/>
 ```
 
 Add the following elements in order to create a thread pool for the Job Executor:


### PR DESCRIPTION
As part of vanilla JBoss/WildFly, I didn't see org.jboss.as.threads extension in standalone.xml. This resulted in error at server startup. As a newbie JBoss, I had to spend an hour to figure this out. It diverts me from setting up Camunda. So I am adding this extension in documentation. 