### PR TITLE
Minor doc fix (asyncAfter)

### DIFF
--- a/content/user-guide/process-engine/transactions-in-processes.md
+++ b/content/user-guide/process-engine/transactions-in-processes.md
@@ -147,7 +147,7 @@ execution flow:
 * an asynchronous continuation BEFORE an activity breaks the execution flow between the invocation
   of the incoming sequence flow's TAKE listeners and the execution of the activity's START
 listeners.
-* an asynchronous continuation AFTER an activity breaks the execution flow after the invocation of
+* an asynchronous continuation AFTER an activity breaks the execution flow between the invocation of
   the activity's END listeners and the outgoing sequence flow's TAKE listeners.
 
 Asynchronous continuations directly relate to transaction boundaries: putting an asynchronous


### PR DESCRIPTION
- According to process-engine-async.png asyncAfter breaks execution BETWEEN the invocation of activity's END listeners and the outgoing sequence flow's TAKE listeners. Either the picture or text is incorrect. This commit fixes the text to match the picture.