### PR TITLE
fix code example

### DIFF
--- a/content/reference/bpmn20/events/message-events.md
+++ b/content/reference/bpmn20/events/message-events.md
@@ -96,7 +96,7 @@ If the type is set to `execution`, then the result contains an `Execution` objec
 
 ```java
 // correlate the message
-MessageCorrelatedResult result = runtimeService.createMessageCorrelation("messageName")
+MessageCorrelationResult result = runtimeService.createMessageCorrelation("messageName")
   .processInstanceBusinessKey("AB-123")
   .setVariable("payment_type", "creditCard")
   .correlateWithResult();


### PR DESCRIPTION
A code example uses the not existing 'MessageCorrelatedResult' interface.
This was fixed to the correct 'MessageCorrelationResult' interface.