### PR TITLE
update post-create.md

### DIFF
--- a/content/reference/rest/authorization/get-query.md
+++ b/content/reference/rest/authorization/get-query.md
@@ -105,7 +105,7 @@ Each group object has the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -120,7 +120,7 @@ Each group object has the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
 </table>
 

--- a/content/reference/rest/authorization/get.md
+++ b/content/reference/rest/authorization/get.md
@@ -64,7 +64,7 @@ A JSON array with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -79,7 +79,7 @@ A JSON array with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
   <tr>
     <td>links</td>

--- a/content/reference/rest/authorization/post-create.md
+++ b/content/reference/rest/authorization/post-create.md
@@ -45,7 +45,7 @@ A JSON object with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -60,7 +60,7 @@ A JSON object with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
 </table>
 
@@ -93,7 +93,7 @@ A JSON array with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -108,7 +108,7 @@ A JSON array with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
   <tr>
     <td>links</td>

--- a/content/reference/rest/authorization/put-update.md
+++ b/content/reference/rest/authorization/put-update.md
@@ -55,7 +55,7 @@ A JSON object with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -70,7 +70,7 @@ A JSON object with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
 </table>
 


### PR DESCRIPTION
The example uses "*" for the "wildcard" specification, but the string "\*" is referenced in several places in the documentation for the service. I haven't verified this in actual code, but it seems very unlikely to me that the wildcard string would be "\*". I'm guessing it's more likely the example would have been tested, as opposed to the documentation.