### PR TITLE
Fix batch typos

### DIFF
--- a/content/reference/rest/authorization/get-query.md
+++ b/content/reference/rest/authorization/get-query.md
@@ -105,7 +105,7 @@ Each group object has the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -120,7 +120,7 @@ Each group object has the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
 </table>
 

--- a/content/reference/rest/authorization/get.md
+++ b/content/reference/rest/authorization/get.md
@@ -64,7 +64,7 @@ A JSON array with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -79,7 +79,7 @@ A JSON array with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
   <tr>
     <td>links</td>

--- a/content/reference/rest/authorization/post-create.md
+++ b/content/reference/rest/authorization/post-create.md
@@ -45,7 +45,7 @@ A JSON object with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -60,7 +60,7 @@ A JSON object with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
 </table>
 
@@ -93,7 +93,7 @@ A JSON array with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -108,7 +108,7 @@ A JSON array with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
   <tr>
     <td>links</td>

--- a/content/reference/rest/authorization/put-update.md
+++ b/content/reference/rest/authorization/put-update.md
@@ -55,7 +55,7 @@ A JSON object with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -70,7 +70,7 @@ A JSON object with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
 </table>
 

--- a/content/reference/rest/batch/get-query.md
+++ b/content/reference/rest/batch/get-query.md
@@ -155,7 +155,7 @@ Each batch object has the following properties:
   <tr>
     <td>suspended</td>
     <td>Boolean</td>
-    <td>Indicates wheter this batch is suspened or not.</td>
+    <td>Indicates wheter this batch is suspended or not.</td>
   </tr>
   <tr>
     <td>tenantId</td>
@@ -211,7 +211,7 @@ Status 200.
     "seedJobDefinitionId": "aSeedJobDefinitionId",
     "monitorJobDefinitionId": "aMonitorJobDefinitionId",
     "batchJobDefinitionId": "aBatchJobDefinitionId",
-    "suspened": false,
+    "suspended": false,
     "tenantId": "aTenantId"
   }
 ]

--- a/content/reference/rest/batch/get-statistics-query.md
+++ b/content/reference/rest/batch/get-statistics-query.md
@@ -155,7 +155,7 @@ Each batch statistics object has the following properties:
   <tr>
     <td>suspended</td>
     <td>Boolean</td>
-    <td>Indicates wheter this batch is suspened or not.</td>
+    <td>Indicates wheter this batch is suspended or not.</td>
   </tr>
   <tr>
     <td>tenantId</td>

--- a/content/reference/rest/batch/get.md
+++ b/content/reference/rest/batch/get.md
@@ -163,7 +163,7 @@ Status 200.
   "seedJobDefinitionId": "aSeedJobDefinitionId",
   "monitorJobDefinitionId": "aMonitorJobDefinitionId",
   "batchJobDefinitionId": "aBatchJobDefinitionId",
-  "suspened": false,
+  "suspended": false,
   "tenantId": "aTenantId"
 }
 ```

--- a/content/reference/rest/batch/get.md
+++ b/content/reference/rest/batch/get.md
@@ -108,7 +108,7 @@ Its properties are as follows:
   <tr>
     <td>suspended</td>
     <td>Boolean</td>
-    <td>Indicates wheter this batch is suspened or not.</td>
+    <td>Indicates whether this batch is suspended or not.</td>
   </tr>
   <tr>
     <td>tenantId</td>


### PR DESCRIPTION
Almost all cases of changing "suspened" to "suspended".