### PR TITLE
Fix case definition typos

### DIFF
--- a/content/reference/rest/authorization/get-query.md
+++ b/content/reference/rest/authorization/get-query.md
@@ -105,7 +105,7 @@ Each group object has the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -120,7 +120,7 @@ Each group object has the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
 </table>
 

--- a/content/reference/rest/authorization/get.md
+++ b/content/reference/rest/authorization/get.md
@@ -64,7 +64,7 @@ A JSON array with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -79,7 +79,7 @@ A JSON array with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
   <tr>
     <td>links</td>

--- a/content/reference/rest/authorization/post-create.md
+++ b/content/reference/rest/authorization/post-create.md
@@ -45,7 +45,7 @@ A JSON object with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -60,7 +60,7 @@ A JSON object with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
 </table>
 
@@ -93,7 +93,7 @@ A JSON array with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -108,7 +108,7 @@ A JSON array with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
   <tr>
     <td>links</td>

--- a/content/reference/rest/authorization/put-update.md
+++ b/content/reference/rest/authorization/put-update.md
@@ -55,7 +55,7 @@ A JSON object with the following properties:
   <tr>
     <td>userId</td>
     <td>String</td>
-    <td>The id of the user this authorization has been created for. The value "\*" represents a global authorization ranging over all users.</td>
+    <td>The id of the user this authorization has been created for. The value "*" represents a global authorization ranging over all users.</td>
   </tr>
   <tr>
     <td>groupId</td>
@@ -70,7 +70,7 @@ A JSON object with the following properties:
   <tr>
     <td>resourceId</td>
     <td>String</td>
-    <td>The resource Id. The value "\*" represents an authorization ranging over all instances of a resource.</td>
+    <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
 </table>
 

--- a/content/reference/rest/case-definition/get-query-count.md
+++ b/content/reference/rest/case-definition/get-query-count.md
@@ -38,7 +38,7 @@ GET `/case-definition/count`
   </tr>
   <tr>
     <td>caseDefinitionIdIn</td>
-    <td>Filter by case definition ids.</td>
+    <td>Filter by a comma-separated list of case definition ids.</td>
   </tr>
   <tr>
     <td>name</td>

--- a/content/reference/rest/case-definition/get-query.md
+++ b/content/reference/rest/case-definition/get-query.md
@@ -37,7 +37,7 @@ GET `/case-definition`
   </tr>
   <tr>
     <td>caseDefinitionIdIn</td>
-    <td>Filter by case definition ids.</td>
+    <td>Filter by a comma-separated list of case definition ids.</td>
   </tr>
   <tr>
     <td>name</td>


### PR DESCRIPTION
Fixed a couple of typos in the reference pages for the rest api for case-definition.