### PR TITLE
Add link to Reference/Spin documentation

### DIFF
--- a/content/user-guide/data-formats/json.md
+++ b/content/user-guide/data-formats/json.md
@@ -26,6 +26,12 @@ The following provides examples on how Camunda Spin can be used in the process e
 
 If you want to learn how to use JSON objects in an embedded form, please take a look at the [Embedded Forms Reference]({{< relref "reference/embedded-forms/json-data.md" >}}).
 
+# Spin Documentation
+
+Further documentation about the usage of SPIN can be found in the [Camunda Spin Dataformat Reference]({{< relref "reference/spin" >}}).
+
+1. [XML]({{< relref "reference/spin/xml" >}})
+2. [JSON]({{< relref "reference/spin/json" >}})
 
 # Expression Language Integration
 


### PR DESCRIPTION
Google search results typically land on the JSON page, but there is no link to the XML and JSON spin data format reference documentation. This change adds the links so you do not have to re-search in the camunda docs for "json" in order to get to the spin reference docs.