### PR TITLE
fix(databaseSchemaUpdate): describe actual behavior since version 6.0

### DIFF
--- a/content/user-guide/process-engine/database.md
+++ b/content/user-guide/process-engine/database.md
@@ -158,8 +158,8 @@ The following properties can be set, regardless of whether you are using the JDB
 
 * `databaseType`: It's normally not necessary to specify this property as it is automatically analyzed from the database connection meta data. Should only be specified in case automatic detection fails. Possible values: {h2, mysql, oracle, postgres, mssql, db2, mariadb}. This setting will determine which create/drop scripts and queries will be used. See the 'supported databases' section for an overview of which types are supported.</li>
 * `databaseSchemaUpdate`: Allows to set the strategy to handle the database schema on process engine boot and shutdown.
-  * `false` (default): Checks the version of the DB schema against the library when the process engine is being created and throws an exception if the versions don't match.
-  * `true`: Upon building the process engine, a check is performed and an update of the schema is performed if necessary. If the schema doesn't exist, it is created.
+  * `true` (default): Upon building the process engine, a check is performed whether the Camunda tables exist in the database. If they don't exist, they are created. It must be ensured that the version of the DB schema matches the version of the process engine library, unless performing a [Rolling Update]({{< relref "update/rolling-update/" >}}). Updates of the database schema have to be done manually as described in the [Update and Migration Guide]({{< relref "update/" >}}).
+  * `false`: Does not perform any checks and assumes that the Camunda table exist in the database. It must be ensured that the version of the DB schema matches the version of the process engine library, unless performing a [Rolling Update]({{< relref "update/rolling-update/" >}}). Updates of the database schema have to be done manually as described in the [Update and Migration Guide]({{< relref "update/" >}}).
   * `create-drop`: Creates the schema when the process engine is being created and drops the schema when the process engine is being closed.
 
 {{< note title="Supported Databases" class="info" >}}


### PR DESCRIPTION
IRC, automatic updates of the schema are disabled since version 6.0. We always write schemaVersion=fox into the ACT_GE_PROPERTY table. Therefore the engine cannot know if the database schema is in the correct version or needs to be updated. The schema version must be ensured by the admin.

I tried this, by running a 7.7.0-ee engine on a 7.6.1-ee schema with databaseSchemaUpdate=true. The engine started without errors, but failed later during the deployment of a process because columns added in 7.7 could not be found:
> ENGINE-03004 Exception while executing Database Operation 'INSERT ProcessDefinitionEntity[...]' with message 'Error updating database.  Cause: org.h2.jdbc.JdbcSQLException: Column "HISTORY_TTL_" not found; ...'