### PR TITLE
Field Injection for Delegate Expressions

### DIFF
--- a/content/user-guide/process-engine/delegation-code.md
+++ b/content/user-guide/process-engine/delegation-code.md
@@ -95,7 +95,7 @@ setter/private field on the injection target should always be `org.camunda.bpm.e
 {{< /note >}}
 
 The following code snippet shows how to inject a constant value into a field.
-Field Injection is supported when using the `class` attribute. Note that we need
+Field Injection is supported when using the `class` or `delegateExpression` attribute. Note that we need
 to declare a `extensionElements` XML element before the actual field injection
 declarations, which is a requirement of the BPMN 2.0 XML Schema.
 


### PR DESCRIPTION
The documentation of Field Injections currently states that these are only supported for delegate classes specified via the `class` attribute which is incorrect. Support for the same feature for classes specified via `delegateExpression`s was originally introduced in 2012 back in the Activiti times, see camunda/fox-engine@c7ae3f31673a89ee24c9615587f0f1e3e3f6b087.