### PR TITLE
Add example for Process Instance Restart REST API

### DIFF
--- a/content/reference/rest/process-definition/post-restart-process-instance-sync.md
+++ b/content/reference/rest/process-definition/post-restart-process-instance-sync.md
@@ -157,13 +157,13 @@ Request Body:
 }
 ```
 
-## Restarting one or more Process Instances using a historicProcessInstanceQuery:
-
 ### Response
 
 Status 204. No content.
 
-## Request
+## Restarting one or more Process Instances using a historicProcessInstanceQuery:
+
+### Request
 
 POST `/process-definition/aProcessDefinitionId/restart`
 
@@ -187,7 +187,7 @@ Request Body:
 }
 ```
 
-## Response
+### Response
 
 Status 204. No content.
 

--- a/content/reference/rest/process-definition/post-restart-process-instance-sync.md
+++ b/content/reference/rest/process-definition/post-restart-process-instance-sync.md
@@ -131,7 +131,9 @@ This method returns no content.
 
 # Example
 
-## Request
+## Restarting one or more Process Instances with known processInstanceIds:
+
+### Request
 
 POST `/process-definition/aProcessDefinitionId/restart`
 
@@ -151,6 +153,32 @@ Request Body:
   ],
   "initialVariables" : true,
   "skipCustomListeners" : true,
+  "withoutBusinessKey" : true
+}
+```
+
+## Restarting one or more Process Instances using a historicProcessInstanceQuery:
+
+### Response
+
+Status 204. No content.
+
+## Request
+
+POST `/process-definition/aProcessDefinitionId/restart`
+
+Request Body:
+
+```json
+{
+  "instructions": [
+    {
+      "type": "startAfterActivity",
+      "activityId": "aUserTask"
+    }
+  ],
+  "initialVariables" : true,
+  "skipCustomListeners" : true,
   "withoutBusinessKey" : true,
   "historicProcessInstanceQuery": {
     "processDefinitionId": "aProcessDefinitionId",
@@ -162,3 +190,4 @@ Request Body:
 ## Response
 
 Status 204. No content.
+


### PR DESCRIPTION
The existing example is not very intuitive because normally one only uses one of the two options (processInstanceId or historicProcessInstanceQuery). I added another example to better show the different ways of finding the right instance.