### PR TITLE
Update get-form-variables.md

### DIFF
--- a/content/reference/rest/task/get-form-variables.md
+++ b/content/reference/rest/task/get-form-variables.md
@@ -12,8 +12,7 @@ menu:
 
 ---
 
-Retrieves the form variables for a task (only if they are defined via the
-[Generated Task Form]({{< relref "user-guide/task-forms/index.md#generated-task-forms" >}}) approach).
+Retrieves the form variables for a task.
 The form variables take form data specified on the task into
 account. If form fields are defined, the variable types and
 default values of the form fields are taken into account.


### PR DESCRIPTION
This endpoint is used in the camunda tasklist for embedded forms, too. I believe we should not mention that this applies only for generated forms - or do I misunderstand the brackets?
It is possible to retrieve variables by name by this endpoint even if they are not defined in the BPMN.