### PR TITLE
mention the jdbcBatchProcessing setting

### DIFF
--- a/content/reference/deployment-descriptors/tags/process-engine.md
+++ b/content/reference/deployment-descriptors/tags/process-engine.md
@@ -400,7 +400,7 @@ The following is a list with the most commonly used process engine configuration
     <td>
         Controls if the engine executes the jdbc statements as Batch or not.
       <p>
-        Default is <code><strong>true</strong></code>, but this has to be disabled for some databases. See <a href="{{<relref "user-guide/process-engine/database/#database-configuration" >}}">the user guide</a> for further details.
+        Default is <code><strong>true</strong></code>, but this has to be disabled for some databases. See <a href="{{<relref "user-guide/process-engine/database/#jdbc-batch-processing" >}}">the user guide</a> for further details.
       </p>
     </td>
   </tr>  

--- a/content/reference/deployment-descriptors/tags/process-engine.md
+++ b/content/reference/deployment-descriptors/tags/process-engine.md
@@ -394,7 +394,16 @@ The following is a list with the most commonly used process engine configuration
       </p>
     </td>
   </tr>
-
+  <tr>
+    <td><code>jdbcBatchProcessing</code></td>
+    <td>Boolean</td>
+    <td>
+        Controls if the engine executes the jdbc statements as Batch or not.
+      <p>
+        Default is <code><strong>true</strong></code>, but this has to be disabled for some databases. See <a href="{{<relref "user-guide/process-engine/database/#database-configuration" >}}">the user guide</a> for further details.
+      </p>
+    </td>
+  </tr>  
   <tr>
     <td><code>jobExecutorAcquireByDueDate</code></td>
     <td>Boolean</td>


### PR DESCRIPTION
Some customers ask for this, because they get database exceptions after upgrading to 7.8.

And the documentation is hidden in a bunch of other settings. It is not clear to them, where to set the property.