### PR TITLE
doc(rest): clarify query parameter in history activity instance query

### DIFF
--- a/content/reference/rest/execution/post-query.md
+++ b/content/reference/rest/execution/post-query.md
@@ -110,25 +110,25 @@ A JSON object with the following properties:
   <tr>
     <td>variables</td>
     <td>A JSON array to only include executions that have variables with certain values. <br/>
-    The array consists of objects with the three properties <code>key</code>, <code>operator</code> and <code>value</code>.
-    <code>key (String)</code> is the variable name, <code>operator (String)</code> is the comparison operator to be used and <code>value</code> the variable value.<br/>
+    The array consists of objects with the three properties <code>name</code>, <code>operator</code> and <code>value</code>.
+    <code>name (String)</code> is the variable name, <code>operator (String)</code> is the comparison operator to be used and <code>value</code> the variable value.<br/>
     <code>value</code> may be <code>String</code>, <code>Number</code> or <code>Boolean</code>.
     <br/>
     Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to; <code>gt</code> - greater than;
     <code>gteq</code> - greater than or equal to; <code>lt</code> - lower than; <code>lteq</code> - lower than or equal to;
-    <code>like</code>.<br/>
-    <code>key</code> and <code>value</code> may not contain underscore characters.
+    <code>like</code>.
     </td>
   </tr>
   <tr>
     <td>processVariables</td>
     <td>A JSON array to only include executions that belong to a process instance with variables with certain values. <br/>
-    A valid parameter value has the form <code>key_operator_value</code>.
-    <code>key</code> is the variable name, <code>operator</code> is the comparison operator to be used and <code>value</code> the variable value.<br/>
-    <strong>Note:</strong> Values are always treated as <code>String</code> objects on server side.<br/>
+    The array consists of objects with the three properties <code>name</code>, <code>operator</code> and <code>value</code>.
+    <code>name (String)</code> is the variable name, <code>operator (String)</code> is the comparison operator to be used and <code>value</code> the variable value.<br/>
+    <code>value</code> may be <code>String</code>, <code>Number</code> or <code>Boolean</code>.
     <br/>
-    Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to.<br/>
-    <code>key</code> and <code>value</code> may not contain underscore characters.
+    Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to; <code>gt</code> - greater than;
+    <code>gteq</code> - greater than or equal to; <code>lt</code> - lower than; <code>lteq</code> - lower than or equal to;
+    <code>like</code>.
     </td>
   </tr>
   <tr>

--- a/content/reference/rest/history/activity-instance/get-activity-instance-query-count.md
+++ b/content/reference/rest/history/activity-instance/get-activity-instance-query-count.md
@@ -65,19 +65,22 @@ GET `/history/activity-instance/count`
   </tr>
   <tr>
     <td>finished</td>
-    <td>Only include finished activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include finished activity instances. Value may only be <code>true</code>, as <code>false</code> behaves the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>unfinished</td>
-    <td>Only include unfinished activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include unfinished activity instances. Value may only be <code>true</code>, as <code>false</code>
+    behaves the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>canceled</td>
-    <td>Only include canceled activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include canceled activity instances. Value may only be <code>true</code>, as <code>false</code> behaves
+    the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>completeScope</td>
-    <td>Only include activity instances which completed a scope. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include activity instances which completed a scope. Value may only be <code>true</code>, as <code>false</code>
+    behaves the same as when the property is not set.</td>
   </tr>
   <tr>
   <td>startedBefore</td>

--- a/content/reference/rest/history/activity-instance/get-activity-instance-query.md
+++ b/content/reference/rest/history/activity-instance/get-activity-instance-query.md
@@ -65,19 +65,22 @@ GET `/history/activity-instance`
   </tr>
   <tr>
     <td>finished</td>
-    <td>Only include finished activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include finished activity instances. Value may only be <code>true</code>, as <code>false</code> behaves the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>unfinished</td>
-    <td>Only include unfinished activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include unfinished activity instances. Value may only be <code>true</code>, as <code>false</code>
+    behaves the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>canceled</td>
-    <td>Only include canceled activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include canceled activity instances. Value may only be <code>true</code>, as <code>false</code> behaves
+    the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>completeScope</td>
-    <td>Only include activity instances which completed a scope. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include activity instances which completed a scope. Value may only be <code>true</code>, as <code>false</code>
+    behaves the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>startedBefore</td>

--- a/content/reference/rest/history/activity-instance/post-activity-instance-query-count.md
+++ b/content/reference/rest/history/activity-instance/post-activity-instance-query-count.md
@@ -66,19 +66,22 @@ A JSON object with the following properties:
   </tr>
   <tr>
     <td>finished</td>
-    <td>Only include finished activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include finished activity instances. Value may only be <code>true</code>, as <code>false</code> behaves the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>unfinished</td>
-    <td>Only include unfinished activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include unfinished activity instances. Value may only be <code>true</code>, as <code>false</code>
+    behaves the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>canceled</td>
-    <td>Only include canceled activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include canceled activity instances. Value may only be <code>true</code>, as <code>false</code> behaves
+    the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>completeScope</td>
-    <td>Only include activity instances which completed a scope. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include activity instances which completed a scope. Value may only be <code>true</code>, as <code>false</code>
+    behaves the same as when the property is not set.</td>
   </tr>
   <tr>
   <td>startedBefore</td>

--- a/content/reference/rest/history/activity-instance/post-activity-instance-query.md
+++ b/content/reference/rest/history/activity-instance/post-activity-instance-query.md
@@ -80,19 +80,22 @@ A JSON object with the following properties:
   </tr>
   <tr>
     <td>finished</td>
-    <td>Only include finished activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include finished activity instances. Value may only be <code>true</code>, as <code>false</code> behaves the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>unfinished</td>
-    <td>Only include unfinished activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include unfinished activity instances. Value may only be <code>true</code>, as <code>false</code>
+    behaves the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>canceled</td>
-    <td>Only include canceled activity instances. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include canceled activity instances. Value may only be <code>true</code>, as <code>false</code> behaves
+    the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>completeScope</td>
-    <td>Only include activity instances which completed a scope. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+    <td>Only include activity instances which completed a scope. Value may only be <code>true</code>, as <code>false</code>
+    behaves the same as when the property is not set.</td>
   </tr>
   <tr>
     <td>startedBefore</td>


### PR DESCRIPTION
The query parameter of REST history activity instance API could use a little more explanation. Otherwise I would expect a query with

> {"canceled": false}

to only return activity instances with property `canceled` value `false`

See forum thread
https://forum.camunda.org/t/rest-can-not-query-for-not-canceled-activity-instances/7044