### PR TITLE
Fix names in section on execution time validation

### DIFF
--- a/content/user-guide/process-engine/process-instance-migration.md
+++ b/content/user-guide/process-engine/process-instance-migration.md
@@ -757,8 +757,8 @@ that the plan is applicable. In particular, the following aspects are checked:
 * **Instruction Applicability**: For certain activity types, only transition instances but not
   activity instances can be migrated
 
-If validation reports errors, migration fails with a `MigrationInstructionInstanceValidationException`
-providing a `MigrationInstructionInstanceValidationReport` object with details on the
+If validation reports errors, migration fails with a `MigratingProcessInstanceValidationException`
+providing a `MigratingProcessInstanceValidationReport` object with details on the
 validation errors.
 
 #### Completeness


### PR DESCRIPTION
Renamed `MigrationInstructionInstanceValidationReport` to `MigratingProcessInstanceValidationReport` and `MigrationInstructionInstanceValidationException` to `MigratingProcessInstanceValidationException`.