### PR TITLE
Fixed URL in create case instance response

### DIFF
--- a/content/reference/rest/case-definition/post-create-case-instance.md
+++ b/content/reference/rest/case-definition/post-create-case-instance.md
@@ -173,7 +173,7 @@ Request Body:
 ## Response
 
     {
-      "links":[{"method": "GET", "href":"http://localhost:8080/rest-test/process-instance/anId","rel":"self"}],
+      "links":[{"method": "GET", "href":"http://localhost:8080/rest-test/case-instance/anId","rel":"self"}],
       "id":"anId",
       "caseDefinitionId":"aCaseDefinitionId",
       "tenantId":null,


### PR DESCRIPTION
Changed the URL in the example response for creating a case instance from `process-instance` to the proper `case-instance` resource.