### PR TITLE
docs(rest): Add the property suspended to task query

### DIFF
--- a/content/reference/rest/task/get-query.md
+++ b/content/reference/rest/task/get-query.md
@@ -616,6 +616,11 @@ Each task object has the following properties:
     <td>The task's key.</td>
   </tr>
   <tr>
+    <td>suspended</td>
+    <td>Boolean</td>
+    <td>Whether the task belongs to a process instance that is suspended.</td>
+  </tr>
+  <tr>
     <td>formKey</td>
     <td>String</td>
     <td>If not null, the form key for the task.</td>

--- a/content/reference/rest/task/get.md
+++ b/content/reference/rest/task/get.md
@@ -141,6 +141,11 @@ Its properties are as follows:
     <td>The task definition key.</td>
   </tr>
   <tr>
+    <td>suspended</td>
+    <td>Boolean</td>
+    <td>Whether the task belongs to a process instance that is suspended.</td>
+  </tr>
+  <tr>
     <td>formKey</td>
     <td>String</td>
     <td>If not null, the form key for the task.</td>

--- a/content/reference/rest/task/post-query.md
+++ b/content/reference/rest/task/post-query.md
@@ -648,6 +648,11 @@ Each task object has the following properties:
     <td>The task's key.</td>
   </tr>
   <tr>
+    <td>suspended</td>
+    <td>Boolean</td>
+    <td>Whether the task belongs to a process instance that is suspended.</td>
+  </tr>
+  <tr>
     <td>formKey</td>
     <td>String</td>
     <td>If not null, the form key for the task.</td>


### PR DESCRIPTION
Add the `suspended` property to docs for REST task query following the discussion https://forum.camunda.org/t/the-suspended-property-of-task/7781.