### PR TITLE
Document limitations of BpmnError

### DIFF
--- a/content/user-guide/process-engine/delegation-code.md
+++ b/content/user-guide/process-engine/delegation-code.md
@@ -480,5 +480,11 @@ Throwing a `BpmnError` in the delegation code behaves like modeling an error end
 
 {{< /note >}}
 
+{{< note title="" class="warning" >}}
+
+Beware that currently throwing `BpmnError`'s from execution listeners (but not Java delegates) has limitations. The error will be treated as a runtime exception and will not be matched using error code by the boundary event.
+
+{{< /note >}}
+
 [script-sources]: {{< relref "user-guide/process-engine/scripting.md#script-source" >}}
 [camunda-script]: {{< relref "reference/bpmn20/custom-extensions/extension-elements.md#camunda-script" >}}


### PR DESCRIPTION
I wanted to clarify the limitations of throwing BpmnError's from execution listeners. I always treated execution listeners just like any other delegation code and was surprised that BpmnErrors thrown from them were not caught by the boundary event, but turned into incidents. I found out that there is a corresponding [feature request](https://app.camunda.com/jira/browse/CAM-5399). Until it is implemented, it is good to have a warning about it in the docs.