### PR TITLE
fix(links): change malformed or mistyped links to intended target

### DIFF
--- a/content/installation/cycle.md
+++ b/content/installation/cycle.md
@@ -110,7 +110,7 @@ To exchange the preconfigured H2 database with your own, e.g., Oracle, you have 
 **Note**: This step is optional and can be skipped if you do not require Cycle to send a welcome email to newly created users.
 
 {{< note title="Java Mail Library" class="info" >}}
-  You need to install the java mail library when NOT using the prepackaged distribution. Download version 1.4.x manually from [http://mvnrepository.com/artifact/javax.mail/mail](href=http://mvnrepository.com/artifact/javax.mail/mail) and copy it into your `$TOMCAT_HOME/lib` folder.
+  You need to install the java mail library when NOT using the prepackaged distribution. Download version 1.4.x manually from [http://mvnrepository.com/artifact/javax.mail/mail](http://mvnrepository.com/artifact/javax.mail/mail) and copy it into your `$TOMCAT_HOME/lib` folder.
 {{< /note >}}
 
 In order to use the Cycle email service, you have to configure a mail session in the `META-INF/context.xml` file in the Cycle web application.

--- a/content/reference/bpmn20/events/conditional-events.md
+++ b/content/reference/bpmn20/events/conditional-events.md
@@ -240,7 +240,7 @@ If we have started the process above and `UserTask B` and `UserTask A` are activ
        SubProcess
          UserTask B
 
-If a variable is set in the context of the `SubProcess` instance, then only the conditional boundary event of `UserTask B` is evaluated. The boundary event of `UserTask A` cannot trigger as the variable is not *visible* in its context. The user guide section on [variable scopes and variable visibility](({{< relref "user-guide/process-engine/variables.md#variable-scopes-and-variable-visibility">}})) provides details on the general concept.
+If a variable is set in the context of the `SubProcess` instance, then only the conditional boundary event of `UserTask B` is evaluated. The boundary event of `UserTask A` cannot trigger as the variable is not *visible* in its context. The user guide section on [variable scopes and variable visibility]({{< relref "user-guide/process-engine/variables.md#variable-scopes-and-variable-visibility">}}) provides details on the general concept.
 
 # Camunda Extensions
 

--- a/content/reference/bpmn20/events/error-events.md
+++ b/content/reference/bpmn20/events/error-events.md
@@ -177,4 +177,4 @@ An error can be handled by the error start event in the event sub process and th
 ## Additional Resources
 
 *   [Error Events](http://camunda.org/bpmn/reference.html#events-error) in the [BPMN 2.0 Modeling Reference](http://camunda.org/bpmn/reference.html)
-*   [Incidents]({{< relref "user-guide/process-engine/incidents.md" >}}) in the [User Guide](red:/guides/user-guide/)
+*   [Incidents]({{< relref "user-guide/process-engine/incidents.md" >}}) in the [User Guide]({{< relref "user-guide/index.md" >}})

--- a/content/reference/rest/process-instance/post-query-count.md
+++ b/content/reference/rest/process-instance/post-query-count.md
@@ -14,7 +14,7 @@ menu:
 
 
 Queries for the number of process instances that fulfill the given parameters.
-This method takes the same message body as the [Get Instances (POST)]({{< relref "reference/rest/process-instance/post-query.md" >}} method)
+This method takes the same message body as the [Get Instances (POST)]({{< relref "reference/rest/process-instance/post-query.md" >}}) method
 and therefore it is slightly more powerful than the [Get Instance Count]({{< relref "reference/rest/process-instance/get-query-count.md" >}}) method.
 
 

--- a/content/user-guide/logging.md
+++ b/content/user-guide/logging.md
@@ -31,7 +31,7 @@ On JBoss/Wildfly, logging is directed to the JBoss logging infrastructure. The S
 When using the Camunda Maven modules in a custom application, only the [slf4j] API is pulled in transitively.
 If you do not provide any backend, nothing will actually be logged.
 
-In the following, we provide two alternative examples of how to set up logging. See the [SLF4J Documentation](slf4j-backends) for more detailed information on how to add a logging backend.
+In the following, we provide two alternative examples of how to set up logging. See the [SLF4J Documentation][slf4j-backends] for more detailed information on how to add a logging backend.
 
 ### Example Using Java Util Logging
 


### PR DESCRIPTION
These were found using an automated tool and need to be changed for followup tasks.