### PR TITLE
fixing Incorrect URL for Set Job Retrites Async (POST)

### DIFF
--- a/content/reference/rest/job/post-set-job-retries.md
+++ b/content/reference/rest/job/post-set-job-retries.md
@@ -8,7 +8,7 @@ menu:
     name: "Set Job Retries Async (POST)"
     identifier: "rest-api-job-post-set-job-retries-async"
     parent: "rest-api-job"
-    pre: "POST `/process-instance/retries`"
+    pre: "POST `/job/retries`"
 
 ---
 


### PR DESCRIPTION
This fixes the bug I opened #208 