### PR TITLE
Fix instruction for maven archetype in interactive mode

### DIFF
--- a/content/user-guide/process-applications/maven-archetypes.md
+++ b/content/user-guide/process-applications/maven-archetypes.md
@@ -102,7 +102,7 @@ Sometimes the creation of the very first Maven project fails in Eclipse. If that
 Run the following command in a terminal to generate a project. Maven will allow you to select an archetype and ask you for all parameters needed to configure it:
 
 <pre class="console">
-mvn archetype:generate -Dfilter=org.camunda.bpm.archetype: -DarchetypeCatalog=https://app.camunda.com/nexus/content/repositories/camunda-bpm
+mvn archetype:generate -Dfilter=org.camunda.bpm.archetype: -DarchetypeRepository=https://app.camunda.com/nexus/content/repositories/camunda-bpm
 </pre>
 
 


### PR DESCRIPTION
archetypeCatalog is not supported anymore