### PR TITLE
[CAM-10709]: processInstanceBusinessKeyIn must be an array.

### DIFF
--- a/content/reference/rest/task/post-query.md
+++ b/content/reference/rest/task/post-query.md
@@ -704,7 +704,7 @@ Request Body:
     {"name": "anotherVarName",
     "value": 30,
     "operator": "neq"}],
-"processInstanceBusinessKeyIn": "aBusinessKey,anotherBusinessKey",
+"processInstanceBusinessKeyIn": ["aBusinessKey","anotherBusinessKey"],
 "priority":10,
 "sorting":
     [{"sortBy": "dueDate",


### PR DESCRIPTION
processInstanceBusinessKeyIn must be an array, and not a list of strings.