### PR TITLE
CAM-10254: doc(engine): add update task listener docs

### DIFF
--- a/content/reference/bpmn20/custom-extensions/extension-elements.md
+++ b/content/reference/bpmn20/custom-extensions/extension-elements.md
@@ -1338,7 +1338,9 @@ The following attributes are extension attributes for the `camunda` namespace `h
   <tr>
     <th>Constraints</th>
     <td colspan="2">
-      The <code>event</code> attribute is required and must be one of the task events: <code>create</code>, <code>assignment</code>, <code>complete</code>, <code>delete</code> or <code>timeout</code>
+      The <code>event</code> attribute is required and must be one of the task events: 
+      <code>create</code>, <code>assignment</code>, <code>update</code>, 
+      <code>complete</code>, <code>delete</code> or <code>timeout</code>
     </td>
   </tr>
   <tr>

--- a/content/reference/bpmn20/tasks/user-task.md
+++ b/content/reference/bpmn20/tasks/user-task.md
@@ -251,6 +251,12 @@ public class MyAssignmentHandler implements TaskListener {
 }
 ```
 
+{{< note title="Note" class="info" >}}
+Assigning a task, or setting any other property through a TaskListener, will not result in an
+`assignemnt` or `update` event unless a `TaskService` method is used to perform these actions. This
+is intentional, in order to avoid creating event loops.
+{{< /note >}}
+
 ## Assignments and Identity Service
 
 Although the Camunda engine provides an identity management component, which is exposed through the IdentityService, it does not check whether a provided user is known by the identity component. This allows integration of the engine with existing identity management solutions when it is embedded into an application.

--- a/content/update/minor/711-to-712/_index.md
+++ b/content/update/minor/711-to-712/_index.md
@@ -23,6 +23,7 @@ This document guides you through the update from Camunda BPM `7.11.x` to `7.12.0
 1. For developers: [Security-related HTTP Headers (Webapps)](#security-related-http-headers-webapps)
 1. For developers: [Camunda Commons Typed Values Migration](#camunda-commons-typed-values-migration)
 1. For developers: [Camunda DMN Engine Migration](#camunda-dmn-engine-migration)
+1. For developers: [Task Lifecycle State and Task Events](#task-lifecycle-state-and-task-events)
 
 This guide covers mandatory migration steps as well as optional considerations for initial configuration of new functionality included in Camunda BPM 7.12.
 
@@ -136,3 +137,16 @@ The changes include:
 # Camunda DMN Engine Migration
 
 The **Camunda DMN Engine** is another migration to the `camunda-bpm-platform` repository happening in version 7.12.0. The DMN Engine migration doesn't require any adjustments. However, any contributions to the DMN Engine will need to be addressed to the [camunda-bpm-platform repository](https://github.com/camunda/camunda-bpm-platform/tree/master/engine-dmn).
+
+# Task Lifecycle State and Task Events
+
+The 7.12.0 release provides a more defined User Task lifecycle. This impacts the order in which Task
+events are fired. Previously, when process execution arrived in a User Task, the assignment event
+was fired **before** the create event (if an assignee was set). With the new Task lifecycle, **if**
+an assignee is explicitly set on the User Task, an assignment event will be fired **after** the
+create event is fired.
+
+Any `create` Task Listeners, that depend on the execution of an `assignment` Task Listener, will
+need to be adjusted. The same goes with `assignment` Task Listeners that hold the assumption that
+they are the first to execute. They will need to be adjusted to consider that `create` Task
+ Listeners will be executed before them.

--- a/content/user-guide/process-engine/delegation-code.md
+++ b/content/user-guide/process-engine/delegation-code.md
@@ -321,12 +321,23 @@ A task listener is used to execute custom Java logic or an expression upon the o
 
 A task listener supports following attributes:
 
-* **event (required)**: the type of task event on which the task listener will be invoked. Possible events are:
+* **event (required)**: the type of task event on which the task listener will be invoked. 
+  Possible events are:
     * **create**: occurs when the task has been created and all task properties are set.
-    * **assignment**: occurs when the task is assigned to somebody. Note: when process execution arrives in a userTask, an assignment event will be fired first, before the create event is fired. This might seem like an unnatural order but the reason is pragmatic: when receiving the create event, we usually want to inspect all properties of the task, including the assignee.
-    * **complete**: occurs when the task is completed and just before the task is deleted from the runtime data.
+    * **assignment**: occurs when the task is assigned to somebody. Note: when process execution
+     arrives in a userTask, and an assignee is explicitly set on the user task, an assignment event
+     will be fired after the create event is fired. This leaves us to inspect all properties of
+     the task when we receive the create listener. The assignment event can be used for a more
+     fine grained inspection, when the assignee is actually set.
+    * **update**: occurs when a task property is changed (ex. assignee, owner, priority, etc.). 
+     Note: the initial setting of properties when a task is initialised does not fire an update
+     event.
+    * **complete**: occurs when the task is completed and just before the task is deleted from
+     the runtime data.
     * **delete**: occurs just before the task is deleted from the runtime data.
-	* **timeout**: occurs when the specified timer is due. Note: this event type requires one [timerEventDefinition][timerEventDefinition] child element in the task listener and will only be fired if the [Job Executor][job-executor] is enabled.
+	* **timeout**: occurs when the specified timer is due. Note: this event type requires one
+	 [timerEventDefinition][timerEventDefinition] child element in the task listener and will
+	  only be fired if the [Job Executor][job-executor] is enabled.
 
 
 * **class**: the delegation class that must be called. This class must implement the `org.camunda.bpm.engine.impl.pvm.delegate.TaskListener` interface.


### PR DESCRIPTION
* Add the update event in the list of possible Task events. Also document the exception when task properties are initialised;
* Document that event loops are not possible;
* Change the documentation on the order of firing of assignment and create events. Also document these changes in the migration guide.

Related to CAM-10254