### PR TITLE
CAM-10876: Update process instance restart REST API docs

### DIFF
--- a/content/reference/rest/process-definition/post-restart-process-instance-async.md
+++ b/content/reference/rest/process-definition/post-restart-process-instance-async.md
@@ -12,7 +12,7 @@ menu:
 
 ---
 
-Restarts process instances that were canceled or terminated asynchronously. To execute the restart synchronously,
+Restarts process instances that were canceled or terminated asynchronously. Can also restart completed process instances. It will create a new instance using the original instance information. To execute the restart synchronously,
 use the [Restart Process Instance]({{< ref "/reference/rest/process-definition/post-restart-process-instance-sync.md" >}}) method.
 
 For more information about the difference between synchronous and

--- a/content/reference/rest/process-definition/post-restart-process-instance-sync.md
+++ b/content/reference/rest/process-definition/post-restart-process-instance-sync.md
@@ -12,7 +12,7 @@ menu:
 
 ---
 
-Restarts process instances that were canceled or terminated synchronously. To execute the restart asynchronously,
+Restarts process instances that were canceled or terminated synchronously. Can also restart completed process instances. It will create a new instance using the original instance information. To execute the restart asynchronously,
 use the [Restart Process Instance Async]({{< ref "/reference/rest/process-definition/post-restart-process-instance-async.md" >}}) method.
 
 For more information about the difference between synchronous and


### PR DESCRIPTION
Updated process instance restart REST API docs to indicate they can be used to restart normally completed process instances. Also mentioned it creates a new instance based on the original instance information.