### PR TITLE
CAM-10724: doc(engine): define task event lifecycle

### DIFF
--- a/content/reference/bpmn20/custom-extensions/extension-elements.md
+++ b/content/reference/bpmn20/custom-extensions/extension-elements.md
@@ -1338,7 +1338,9 @@ The following attributes are extension attributes for the `camunda` namespace `h
   <tr>
     <th>Constraints</th>
     <td colspan="2">
-      The <code>event</code> attribute is required and must be one of the task events: <code>create</code>, <code>assignment</code>, <code>complete</code>, <code>delete</code> or <code>timeout</code>
+      The <code>event</code> attribute is required and must be one of the task events: 
+      <code>create</code>, <code>assignment</code>, <code>update</code>, 
+      <code>complete</code>, <code>delete</code> or <code>timeout</code>
     </td>
   </tr>
   <tr>

--- a/content/reference/bpmn20/tasks/user-task.md
+++ b/content/reference/bpmn20/tasks/user-task.md
@@ -251,6 +251,12 @@ public class MyAssignmentHandler implements TaskListener {
 }
 ```
 
+{{< note title="Note" class="info" >}}
+Assigning a task, or setting any other property through a TaskListener, will not result in an
+`assignemnt` or `update` event unless a `TaskService` method is used to perform these actions. This
+is intentional, in order to avoid creating event loops.
+{{< /note >}}
+
 ## Assignments and Identity Service
 
 Although the Camunda engine provides an identity management component, which is exposed through the IdentityService, it does not check whether a provided user is known by the identity component. This allows integration of the engine with existing identity management solutions when it is embedded into an application.

--- a/content/reference/bpmn20/tasks/user-task.md
+++ b/content/reference/bpmn20/tasks/user-task.md
@@ -253,7 +253,7 @@ public class MyAssignmentHandler implements TaskListener {
 
 {{< note title="Note" class="info" >}}
 Assigning a task, or setting any other property through a TaskListener, will not result in an
-`assignemnt` or `update` event unless a `TaskService` method is used to perform these actions. This
+`assignment` or `update` event unless a `TaskService` method is used to perform these actions. This
 is intentional, in order to avoid creating event loops.
 {{< /note >}}
 

--- a/content/update/minor/711-to-712/_index.md
+++ b/content/update/minor/711-to-712/_index.md
@@ -23,6 +23,7 @@ This document guides you through the update from Camunda BPM `7.11.x` to `7.12.0
 1. For developers: [Security-related HTTP Headers (Webapps)](#security-related-http-headers-webapps)
 1. For developers: [Camunda Commons Typed Values Migration](#camunda-commons-typed-values-migration)
 1. For developers: [Camunda DMN Engine Migration](#camunda-dmn-engine-migration)
+1. For developers: [Task Lifecycle State and Task Events](#task-lifecycle-state-and-task-events)
 
 This guide covers mandatory migration steps as well as optional considerations for initial configuration of new functionality included in Camunda BPM 7.12.
 
@@ -136,3 +137,16 @@ The changes include:
 # Camunda DMN Engine Migration
 
 The **Camunda DMN Engine** is another migration to the `camunda-bpm-platform` repository happening in version 7.12.0. The DMN Engine migration doesn't require any adjustments. However, any contributions to the DMN Engine will need to be addressed to the [camunda-bpm-platform repository](https://github.com/camunda/camunda-bpm-platform/tree/master/engine-dmn).
+
+# Task Lifecycle State and Task Events
+
+The 7.12.0 release provides a more defined User Task lifecycle. This impacts the order in which Task
+events are fired. Previously, when process execution arrived in a User Task, the assignment event
+was fired **before** the create event (if an assignee was set). With the new Task lifecycle, **if**
+an assignee is explicitly set on the User Task, an assignment event will be fired **after** the
+create event is fired.
+
+Any `create` Task Listeners, that depend on the execution of an `assignment` Task Listener, will
+need to be adjusted. The same goes with `assignment` Task Listeners that hold the assumption that
+they are the first to execute. They will need to be adjusted to consider that `create` Task
+ Listeners will be executed before them.

--- a/content/update/minor/711-to-712/_index.md
+++ b/content/update/minor/711-to-712/_index.md
@@ -141,12 +141,12 @@ The **Camunda DMN Engine** is another migration to the `camunda-bpm-platform` re
 # Task Lifecycle State and Task Events
 
 The 7.12.0 release provides a more defined User Task lifecycle. This impacts the order in which Task
-events are fired. Previously, when process execution arrived in a User Task, the assignment event
+events are fired. Previously, when the process execution arrived in a User Task, the assignment event
 was fired **before** the create event (if an assignee was set). With the new Task lifecycle, **if**
 an assignee is explicitly set on the User Task, an assignment event will be fired **after** the
 create event is fired.
 
-Any `create` Task Listeners, that depend on the execution of an `assignment` Task Listener, will
+Any `create` Task Listeners that depend on the execution of an `assignment` Task Listener will
 need to be adjusted. The same goes with `assignment` Task Listeners that hold the assumption that
-they are the first to execute. They will need to be adjusted to consider that `create` Task
- Listeners will be executed before them.
+they are the first to execute. They will need to be adjusted to consider that `create` Task Listeners 
+will be executed before them.

--- a/content/update/minor/711-to-712/_index.md
+++ b/content/update/minor/711-to-712/_index.md
@@ -150,3 +150,7 @@ Any `create` Task Listeners that depend on the execution of an `assignment` Task
 need to be adjusted. The same goes with `assignment` Task Listeners that hold the assumption that
 they are the first to execute. They will need to be adjusted to consider that `create` Task Listeners 
 will be executed before them.
+
+Furthermore, `assignment` Task Listeners will no longer be triggered through an assignment within
+another Task Listener. Those that hold this assumption will need to be adjusted, with this
+limitation in mind, by explicitly performing an assignment through the `TaskService`.

--- a/content/user-guide/process-engine/delegation-code.md
+++ b/content/user-guide/process-engine/delegation-code.md
@@ -321,12 +321,23 @@ A task listener is used to execute custom Java logic or an expression upon the o
 
 A task listener supports following attributes:
 
-* **event (required)**: the type of task event on which the task listener will be invoked. Possible events are:
+* **event (required)**: the type of task event on which the task listener will be invoked. 
+  Possible events are:
     * **create**: occurs when the task has been created and all task properties are set.
-    * **assignment**: occurs when the task is assigned to somebody. Note: when process execution arrives in a userTask, an assignment event will be fired first, before the create event is fired. This might seem like an unnatural order but the reason is pragmatic: when receiving the create event, we usually want to inspect all properties of the task, including the assignee.
-    * **complete**: occurs when the task is completed and just before the task is deleted from the runtime data.
+    * **assignment**: occurs when the task is assigned to somebody. Note: when process execution
+     arrives in a userTask, and an assignee is explicitly set on the user task, an assignment event
+     will be fired after the create event is fired. This leaves us to inspect all properties of
+     the task when we receive the create listener. The assignment event can be used for a more
+     fine grained inspection, when the assignee is actually set.
+    * **update**: occurs when a task property is changed (ex. assignee, owner, priority, etc.). 
+     Note: the initial setting of properties when a task is initialised does not fire an update
+     event.
+    * **complete**: occurs when the task is completed and just before the task is deleted from
+     the runtime data.
     * **delete**: occurs just before the task is deleted from the runtime data.
-	* **timeout**: occurs when the specified timer is due. Note: this event type requires one [timerEventDefinition][timerEventDefinition] child element in the task listener and will only be fired if the [Job Executor][job-executor] is enabled.
+	* **timeout**: occurs when the specified timer is due. Note: this event type requires one
+	 [timerEventDefinition][timerEventDefinition] child element in the task listener and will
+	  only be fired if the [Job Executor][job-executor] is enabled.
 
 
 * **class**: the delegation class that must be called. This class must implement the `org.camunda.bpm.engine.impl.pvm.delegate.TaskListener` interface.

--- a/content/user-guide/process-engine/delegation-code.md
+++ b/content/user-guide/process-engine/delegation-code.md
@@ -321,24 +321,24 @@ A task listener is used to execute custom Java logic or an expression upon the o
 
 ## Task Listener Event Lifecycle
 
-The execution of Task Listeners is dependant on the order of firing of 
+The execution of Task Listeners is dependent on the order of firing of 
 the following task-related events:
 
 The **create** event fires when the task has been created and all task properties are set. No
-other task-related event will be fired before the *create* event. The event leaves us to inspect
-all properties of the task when we receive the create listener.
+other task-related event will be fired before the *create* event. The event allows us to inspect
+all properties of the task when we receive it in the create listener.
 
-The **update** event occurs when a task property (ex. assignee, owner, priority, etc.) on an already
+The **update** event occurs when a task property (e.g. assignee, owner, priority, etc.) on an already
 created task is changed. Note that the initial setting of properties when a task is created does
 not fire an update event (the task is being created). This also means that the *update* event
 will always occur after a *create* event has already occurred.
 
-The **assignment** event specifically tracks the changes of the Task `assignee` property. The event
+The **assignment** event specifically tracks the changes of the Task's `assignee` property. The event
 may be fired on two occasions:
 
-1. When a task with an `assignee` explicitly defined in the process definition, has been
+1. When a task with an `assignee` explicitly defined in the process definition has been
 created. In this case, the *assignment* event will be fired after the *create* event.
-1. When an already created task is assigned, i.e. the Task `assignee` property is changed. In
+1. When an already created task is assigned, i.e. the Task's `assignee` property is changed. In
 this case, the *assignment* event will follow the *update* event since changing the `assignee`
 property results in an updated task.
 
@@ -376,7 +376,7 @@ additional Task Events. As with the **complete** event mentioned above, these Ta
 immediately invoke their related Listeners, after which the remaining Task Listeners will be
 processed. However, it should be noted that the chain of events triggered inside the Task Listener,
 by the invocation of the `TaskService` method, will be in the previously described order.
-1. By throwing a BPMN Error event inside a Task Listener (ex. a **complete** event Task Listener).
+1. By throwing a BPMN Error event inside a Task Listener (e.g. a **complete** event Task Listener).
 This would cancel the Task and cause a **delete** event to be fired. 
 
 Under the above-mentioned conditions, users should be careful not to accidentally create a Task
@@ -384,7 +384,7 @@ event loop.
 
 ## Defining a Task Listener
 
-A task listener supports following attributes:
+A task listener supports the following attributes:
 
 * **event (required)**: the type of task event on which the task listener will be invoked. 
     Possible events are: **create**, **assignment**, **update**, **complete**, **delete** and

--- a/content/user-guide/process-engine/delegation-code.md
+++ b/content/user-guide/process-engine/delegation-code.md
@@ -350,11 +350,16 @@ this requires for a Timer to be defined. The `timeout` event may occur after a T
 `created`, and before it has been `completed`.
 
 The **complete** event occurs when the task is _successfully_ completed and just before the task
-is deleted from the runtime data. No other event is fired after the *complete* event, the
-*complete* event results in an end of the task event lifecycle. 
+is deleted from the runtime data. A successful execution of a task's **complete** Task Listeners
+results in an end of the task event lifecycle.
 
-The **delete** event occurs just before the task is deleted from the runtime data, because of an
-interrupting Boundary Event, an interrupting Event Subprocess, or a Process Instance deletion.
+The **delete** event occurs just before the task is deleted from the runtime data, because of:
+
+1. An interrupting Boundary Event;
+1. An interrupting Event Subprocess; 
+1. A Process Instance deletion;
+1. A BPMN Error thrown inside a Task Listener.
+ 
 No other event is fired after the *delete* event since it results in an end of the task event
 lifecycle. This means that the *delete* event is mutually exclusive with the *complete* event.
 
@@ -371,6 +376,8 @@ additional Task Events. As with the **complete** event mentioned above, these Ta
 immediately invoke their related Listeners, after which the remaining Task Listeners will be
 processed. However, it should be noted that the chain of events triggered inside the Task Listener,
 by the invocation of the `TaskService` method, will be in the previously described order.
+1. By throwing a BPMN Error event inside a Task Listener (ex. a **complete** event Task Listener).
+This would cancel the Task and cause a **delete** event to be fired. 
 
 Under the above-mentioned conditions, users should be careful not to accidentally create a Task
 event loop.

--- a/content/user-guide/process-engine/delegation-code.md
+++ b/content/user-guide/process-engine/delegation-code.md
@@ -363,13 +363,14 @@ lifecycle. This means that the *delete* event is mutually exclusive with the *co
 The descriptions above lay out the order in which Task Events are fired. However, this order may be
 disrupted under the following conditions:
 
-1. When a Task is completed inside a Task Listener, the **complete** event will be fired. A Task
-may be completed, and a `complete` event fired through `create`, `update` or `assignment` Task
-Listeners. 
+1. When calling `Task#complete()` inside a Task Listener, the **complete** event will be fired
+right away. The related Task Listeners will be immediately invoked, after which the remaining
+Task Listeners for the previous event will be processed.
 1. By using the `TaskService` methods inside a Task Listener, which may cause the firing of
-additional Task Events that will be fired out-of-order with the existing ones. However, the chain of
-events triggered by the invocation of the `TaskService` method will always be in the above-defined
-order.
+additional Task Events. As with the **complete** event mentioned above, these Task Events will
+immediately invoke their related Listeners, after which the remaining Task Listeners will be
+processed. However, it should be noted that the chain of events triggered inside the Task Listener,
+by the invocation of the `TaskService` method, will be in the previously described order.
 
 Under the above-mentioned conditions, users should be careful not to accidentally create a Task
 event loop.


### PR DESCRIPTION

* Describe order of firing of Task Events;
* Describe limitation of Task Event chaining regarding the order of firing of events.

Related to [CAM-10724](https://app.camunda.com/jira/browse/CAM-10724)