### PR TITLE
CAM-11394: Updates on skipped versions

### DIFF
--- a/content/update/minor/_index.md
+++ b/content/update/minor/_index.md
@@ -15,4 +15,8 @@ menu:
 These documents guide you through the process of updating your application or server installation from one Camunda minor version to the other.
 This applies to any updates of the version number "after the first dot", example: `7.3` to `7.4`.
 
+{{< note title="Skipping Minor Versions" class="warning" >}}
+It is possible to skip minor versions when updating your installation since application updates are cumulative. However, the database alteration scripts are NOT cumulative and need to be executed in version order and must include any skipped versions.
+{{< /note >}}
+
 There is a dedicated update guide for each version:

--- a/content/update/minor/_index.md
+++ b/content/update/minor/_index.md
@@ -15,8 +15,8 @@ menu:
 These documents guide you through the process of updating your application or server installation from one Camunda minor version to the other.
 This applies to any updates of the version number "after the first dot", example: `7.3` to `7.4`.
 
-{{< note title="Skipping Minor Versions" class="warning" >}}
-It is possible to skip minor versions when updating your installation since application updates are cumulative. However, the database alteration scripts are NOT cumulative and need to be executed in version order and must include any skipped versions.
+{{< note title="Do I need to apply every minor version if I missed a few?" class="warning" >}}
+If you need to apply multiple minor versions you MUST execute the database alteration scripts in minor version order as they are NOT cumulative. Application library updates are cumulative and don't necessarily require sequential minor version updates. Typically, you can just apply your target minor application libraries. You should, however, check the instructions of EVERY intermediate minor version in case updating the application libraries is required for a particular minor version.
 {{< /note >}}
 
 There is a dedicated update guide for each version:

--- a/content/update/rolling-update.md
+++ b/content/update/rolling-update.md
@@ -16,7 +16,7 @@ menu:
 Rolling updates are not possible prior to Version `7.5`. Or in other words: the first update that can be done in the way described on this page is the update from version `7.5.x` to `7.6.y`.
 
 Also note that it is only possible to update from one minor version to the next. For example, it is possible to update from `7.5.3` to `7.6.2` in a rolling fashion but it is not possible to update from `7.5.3` to `7.7.2` in one go.
-Before the rolling update from one minor to another can be executed, the latest patch, of the current used minor version, must be applied. 
+Before the rolling update from one minor to another can be executed, the latest patch, of the current used minor version, must be applied to all nodes before proceeding to the next minor version.
 
 More considerations for rolling updates can be found at the bottom of this page. Make sure to read them.
 {{< /note >}}


### PR DESCRIPTION
[![CAM-11394](https://badgen.net/badge/JIRA/CAM-11394/0052CC)](https://app.camunda.com/jira/browse/CAM-11394)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added clarifications on how to 'skip' minor versions by indicating database alteration scripts from every minor version need to be executed. In a rolling update, every node has to be updated before the update to the next minor version can be executed.