### PR TITLE
CAM-11255: doc(dmn/feel): remove feel-scala from the community extensions

### DIFF
--- a/content/introduction/extensions.md
+++ b/content/introduction/extensions.md
@@ -37,7 +37,6 @@ The following is a list of current (unsupported) community extensions:
 * [DMN Scala Extension](https://github.com/camunda/dmn-scala)
 * [Elastic Search Extension](https://github.com/camunda/camunda-bpm-elasticsearch)
 * [Email Connectors](https://github.com/camunda/camunda-bpm-mail)
-* [FEEL Scala Extension](https://github.com/camunda/feel-scala)
 * [Grails Plugin](https://github.com/plexiti/camunda-grails-plugin)
 * [GraphQL API](https://github.com/camunda/camunda-graphql)
 * [Keycloak Identity Provider Plugin](https://github.com/camunda/camunda-bpm-identity-keycloak)

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -158,9 +158,6 @@
             <a href="https://github.com/camunda/camunda-bpm-mail">Email Connectors</a>
           </div>
           <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/feel-scala">FEEL Scala Extension</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
             <a href="https://github.com/plexiti/camunda-grails-plugin">Grails Plugin</a>
           </div>
           <div class="col-xs-6 col-md-4">


### PR DESCRIPTION
[![CAM-11255](https://badgen.net/badge/JIRA/CAM-11255/0052CC)](https://app.camunda.com/jira/browse/CAM-11255)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Remove the Scala FEEL Engine from the lists of community extensions since it is maintained and integrated with the Camunda BPM Platform.

Related to CAM-11255