### PR TITLE
CAM-11399/CAM-11400: doc(dmn/feel): usage of legacy feel engine

### DIFF
--- a/content/reference/deployment-descriptors/tags/process-engine.md
+++ b/content/reference/deployment-descriptors/tags/process-engine.md
@@ -720,6 +720,19 @@ The following is a list with the most commonly used process engine configuration
         The default value is 2<sup>31</sup>-1.
     </td>
   </tr>
+  
+  <tr id="dmnFeelEnableLegacyBehavior">
+    <td><code>dmnFeelEnableLegacyBehavior</code></td>
+    <td>Boolean</td>
+    <td>
+      Set to <code>true</code> to restore the legacy FEEL configuration of the DMN Engine. This
+      will result in the usage of the old, Java-based FEEL Engine, as well as the usage of JUEL
+      in DMN input expressions, output entries and literal expressions. When set to 
+      <code>false</code>, the new, Scala-based FEEL Engine is used, and FEEL is used as the
+      default language for DMN input expressions, input and output entries, and literal expressions.
+      Default value: <code>false</code>
+    </td>
+  </tr>
 
 </table>
 

--- a/content/reference/dmn11/feel/legacy/_index.md
+++ b/content/reference/dmn11/feel/legacy/_index.md
@@ -12,7 +12,20 @@ menu:
 
 ---
 
-The Camunda DMN engine **only** supports FEEL for [input entries] of a
-decision table. This corresponds to FEEL simple unary tests.
+This page provides information on the features of the legacy FEEL Engine, that was used before the 
+current, Scala-based FEEL Engine was integrated into the Camunda BPM Platform.
 
+By using the legacy FEEL Engine, the Camunda DMN engine **only** supports `FEEL` for [input entries] 
+of a decision table. This corresponds to FEEL simple unary tests.
+
+To see how this legacy behavior can be enabled again in the Camunda BPM Platform, please see the
+[dmnFeelEnableLegacyBehavior][legacy behavior flag] engine configuration property. To enable this
+behavior in a standalone DMN Engine setup, please refer to the `DefaultDmnEngineConfiguration`
+[enableFeelLegacyBehavior][fluent feel flag setter] and [setEnableFeelLegacyBehavior][feel flag setter] 
+methods.
+
+
+[legacy behavior flag]: {{< ref "/reference/deployment-descriptors/tags/process-engine.md#dmnFeelEnableLegacyBehavior" >}}
+[fluent feel flag setter]: {{< javadocref_url page="?org/camunda/bpm/dmn/engine/impl/DefaultDmnEngineConfiguration.html#enableFeelLegacyBehavior-boolean-" >}}
+[feel flag setter]: {{< javadocref_url page="?org/camunda/bpm/dmn/engine/impl/DefaultDmnEngineConfiguration.html#setEnableFeelLegacyBehavior-boolean-" >}}
 [input entries]: {{< ref "/reference/dmn11/decision-table/rule.md#input-entry-condition" >}}

--- a/content/user-guide/dmn-engine/expressions-and-scripts.md
+++ b/content/user-guide/dmn-engine/expressions-and-scripts.md
@@ -102,6 +102,11 @@ DMN engine are as follows:
 - *Input Entry*: `FEEL`
 - *Output Entry*: `FEEL`
 - *Literal Expression*: `FEEL`
+ 
+{{< note title="Legacy Behavior" class="info" >}}
+You can find how to go back to the legacy behavior, where `JUEL` was used for input expressions, 
+output entries and literal expressions [here]({{< ref "/reference/deployment-descriptors/tags/process-engine.md#dmnFeelEnableLegacyBehavior" >}}).
+{{< /note >}}
 
 The default language can be changed by setting it directly in the DMN 1.1 XML as global expression language with the `expressionLanguage` attribute of
 the `definitions` element:


### PR DESCRIPTION
[![CAM-11399](https://badgen.net/badge/JIRA/CAM-11399/0052CC)](https://app.camunda.com/jira/browse/CAM-11399)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Document the behaviout of the Process Engine Configuration, legacy FEEL behavior propery flag;
* Note how default Expression Languages can be easily reverted to the legacy behavior;
* Document how the legacy FEEL Engine can be enabled in the reference page.

Related to CAM-11399, CAM-11400

The branch merges into the CAM-11475 since commit 012d6c30 contains code related to CAM-11400. I created a single PR for both CAM-11399 and CAM-11400 since they are closely related and writing the documentation separately would have been inefficient. I can rebase and restructure the commits after the review if that is needed.