### PR TITLE
Set scope=test on Camunda BPM Assert Maven dependencies

### DIFF
--- a/content/user-guide/testing/_index.md
+++ b/content/user-guide/testing/_index.md
@@ -166,6 +166,7 @@ To use Camunda BPM Assert, add the following dependency to your ```pom.xml```:
   <groupId>org.camunda.bpm.assert</groupId>
   <artifactId>camunda-bpm-assert</artifactId>
   <version>5.0.0</version>
+  <scope>test</scope>
 </dependency>
 ```
 
@@ -176,6 +177,7 @@ Also, you will have to add the AssertJ library v3.13.2 to your dependencies with
   <groupId>org.assertj</groupId>
   <artifactId>assertj-core</artifactId>
   <version>3.13.2</version>
+  <scope>test</scope>
 </dependency>
 ```
 
@@ -252,6 +254,7 @@ All versions prior to 3.0.0 belong to the community extension are not part of th
   <groupId>org.camunda.bpm.extension</groupId>
   <artifactId>camunda-bpm-assert</artifactId>
   <version>1.x</version> <!-- set correct version here -->
+  <scope>test</scope>
 </dependency>
 ```
 
@@ -262,6 +265,7 @@ For these versions, use the following Maven coordinates:
   <groupId>org.camunda.bpm.extension</groupId>
   <artifactId>camunda-bpm-assert</artifactId>
   <version>2.x</version> <!-- set correct version here -->
+  <scope>test</scope>
 </dependency>
 ```
 


### PR DESCRIPTION
[![](https://badgen.net/badge/JIRA//0052CC)](https://app.camunda.com/jira/browse/)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Camunda BPM Assert and AssertJ are test tools and should therefore not be shipped to production. Setting the scope to test prevents users that copy the dependencies from accidentally leaking those test jars into their production wars.