### PR TITLE
CAM-11579 In the FEEL section of the Migration Guide, fix typo about double-quoted string literals

### DIFF
--- a/content/update/minor/712-to-713/_index.md
+++ b/content/update/minor/712-to-713/_index.md
@@ -256,7 +256,7 @@ The following exception classes were consolidated to `org.camunda.bpm.dmn.feel.i
 ### Single-Quoted String Literals Not Allowed
 
 Previously, double-quoted as well as single-quoted string literals were allowed.
-The new FEEL Engine is more strict on the specification here. Use single quotes 
+The new FEEL Engine is more strict on the specification here. Use double quotes 
 for string literals in expressions. 
 
 **Example:** Migrate 'foo' to "foo"


### PR DESCRIPTION
[![CAM-11579](https://badgen.net/badge/JIRA/CAM-11579/0052CC)](https://app.camunda.com/jira/browse/CAM-11579)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

