### PR TITLE
Adding for more help on spring and camunda dependencies

### DIFF
--- a/content/user-guide/spring-boot-integration/_index.md
+++ b/content/user-guide/spring-boot-integration/_index.md
@@ -27,7 +27,7 @@ To enable Camunda BPM auto configuration, add the following dependency to your `
 </dependency>
 ```
 
-This will add the Camunda engine v.7.13.0 to your dependencies. For more help on Spring Framework and Camunda dependencies, refer [link](https://start.camunda.com/).
+This will add the Camunda engine v.7.13.0 to your dependencies.
 
 Other starters that can be used are: [`camunda-bpm-spring-boot-starter-rest`](rest-api) and [`camunda-bpm-spring-boot-starter-webapp`](webapps).
 

--- a/content/user-guide/spring-boot-integration/_index.md
+++ b/content/user-guide/spring-boot-integration/_index.md
@@ -15,7 +15,7 @@ Spring boot starters allow to enable behavior of your spring-boot application by
 
 These starters will pre-configure the Camunda process engine, REST API and Web applications, so they can easily be used in a standalone process application.
 
-If you are not familiar with [Spring Boot](http://projects.spring.io/spring-boot/), read the [getting started](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#getting-started) guide.
+If you are not familiar with [Spring Boot](http://projects.spring.io/spring-boot/), read the [getting started](http://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#getting-started) guide or use the [Camunda BPM Initializr](https://start.camunda.com/).
 
 To enable Camunda BPM auto configuration, add the following dependency to your ```pom.xml```:
 


### PR DESCRIPTION
we can add a link which can be used by beginners to build project quickly using spring and camunda dependencies and can focus on camunda learning rather than spending time on building the project. 