### PR TITLE
remove error details from the response.

### DIFF
--- a/content/reference/rest/external-task/get.md
+++ b/content/reference/rest/external-task/get.md
@@ -65,12 +65,6 @@ Its properties are as follows:
     <br/><code>null</code> if no failure was reported previously or if no error message was submitted</td>
   </tr>
   <tr>
-    <td>errorDetails</td>
-    <td>String</td>
-    <td>The error details submitted with the latest reported failure executing this task.
-    <br/><code>null</code> if no failure was reported previously or if no error details was submitted</td>
-  </tr>
-  <tr>
     <td>executionId</td>
     <td>String</td>
     <td>The id of the execution that the external task belongs to.</td>
@@ -171,7 +165,6 @@ GET `/external-task/anExternalTaskId`
       "activityId": "anActivityId",
       "activityInstanceId": "anActivityInstanceId",
       "errorMessage": "anErrorMessage",
-      "errorDetails": "anErrorDetails",
       "executionId": "anExecutionId",
       "id": "anExternalTaskId",
       "lockExpirationTime": "2015-10-06T16:34:42.000+0200",


### PR DESCRIPTION
Related to CAM-11774

The property `errorDetails` is always null, as there is a dedicated endpoint for it.

This is still covered with commit b55f0b0129d586508d61ac051d6c6ae2c24f6658.