### PR TITLE
CAM-11774: fix(rest): remove unused error details property

### DIFF
--- a/content/reference/rest/external-task/get-query.md
+++ b/content/reference/rest/external-task/get-query.md
@@ -163,12 +163,6 @@ Each external task object has the following properties:
     <br/><code>null</code> if no failure was reported previously or if no error message was submitted</td>
   </tr>
   <tr>
-    <td>errorDetails</td>
-    <td>String</td>
-    <td>The error details submitted with the latest reported failure executing this task.
-    <br/><code>null</code> if no failure was reported previously or if no error details was submitted</td>
-  </tr>
-  <tr>
     <td>executionId</td>
     <td>String</td>
     <td>The id of the execution that the external task belongs to.</td>
@@ -276,7 +270,6 @@ Status 200.
       "activityId": "anActivityId",
       "activityInstanceId": "anActivityInstanceId",
       "errorMessage": "anErrorMessage",
-      "errorDetails": "anErrorDetails",
       "executionId": "anExecutionId",
       "id": "anExternalTaskId",
       "lockExpirationTime": "2015-10-06T16:34:42.000+0200",
@@ -295,7 +288,6 @@ Status 200.
       "activityId": "anotherActivityId",
       "activityInstanceId": "anotherActivityInstanceId",
       "errorMessage": "anotherErrorMessage",
-      "errorDetails": "anotherErrorDetails",
       "executionId": "anotherExecutionId",
       "id": "anotherExternalTaskId",
       "lockExpirationTime": "2015-10-06T16:34:42.000+0200",

--- a/content/reference/rest/external-task/post-query.md
+++ b/content/reference/rest/external-task/post-query.md
@@ -189,12 +189,6 @@ Each external task object has the following properties:
         <br/><code>null</code> if no failure was reported previously or if no error message was submitted</td>
       </tr>
       <tr>
-        <td>errorDetails</td>
-        <td>String</td>
-        <td>The error details submitted with the latest reported failure executing this task.
-        <br/><code>null</code> if no failure was reported previously or if no error details was submitted</td>
-      </tr>
-      <tr>
         <td>executionId</td>
         <td>String</td>
         <td>The id of the execution that the external task belongs to.</td>
@@ -318,7 +312,6 @@ Status 200.
       "activityId": "anActivityId",
       "activityInstanceId": "anActivityInstanceId",
       "errorMessage": "anErrorMessage",
-      "errorDetails": "anErrorDetails",
       "executionId": "anExecutionId",
       "id": "anExternalTaskId",
       "lockExpirationTime": "2015-10-06T16:34:42.000+0200",
@@ -337,7 +330,6 @@ Status 200.
       "activityId": "anotherActivityId",
       "activityInstanceId": "anotherActivityInstanceId",
       "errorMessage": "anotherErrorMessage",
-      "errorDetails": "anotherErrorDetails",
       "executionId": "anotherExecutionId",
       "id": "anotherExternalTaskId",
       "lockExpirationTime": "2015-10-06T16:34:42.000+0200",


### PR DESCRIPTION
* Remove the unused and unset External Task errorDetails property from the query endpoints' examples.

Related to CAM-11774