### PR TITLE
docs(rest): add batch id to variable instance endpoints

### DIFF
--- a/content/reference/rest/variable-instance/get-query-count.md
+++ b/content/reference/rest/variable-instance/get-query-count.md
@@ -58,6 +58,10 @@ GET `/variable-instance/count`
     <td>Only include variable instances which belong to one of the passed and comma-separated task ids.</td>
   </tr>
   <tr>
+    <td>batchIdIn</td>
+    <td>Only include variable instances which belong to one of the passed and comma-separated batch ids.</td>
+  </tr>
+  <tr>
     <td>activityInstanceIdIn</td>
     <td>Only include variable instances which belong to one of the passed and comma-separated activity instance ids.</td>
   </tr>

--- a/content/reference/rest/variable-instance/get-query.md
+++ b/content/reference/rest/variable-instance/get-query.md
@@ -59,6 +59,10 @@ GET `/variable-instance`
     <td>Only include variable instances which belong to one of the passed and comma-separated task ids.</td>
   </tr>
   <tr>
+    <td>batchIdIn</td>
+    <td>Only include variable instances which belong to one of the passed and comma-separated batch ids.</td>
+  </tr>
+  <tr>
     <td>activityInstanceIdIn</td>
     <td>Only include variable instances which belong to one of the passed and comma-separated activity instance ids.</td>
   </tr>
@@ -183,6 +187,11 @@ A JSON array of variable instance objects. Each variable instance object has the
     <td>The id of the task that this variable instance belongs to.</td>
   </tr>
   <tr>
+    <td>batchId</td>
+    <td>String</td>
+    <td>The id of the batch that this variable instance belongs to.</td>
+  </tr>
+  <tr>
     <td>activityInstanceId</td>
     <td>String</td>
     <td>The id of the activity instance that this variable instance belongs to.</td>
@@ -235,6 +244,7 @@ GET `/variable-instance?processInstanceIdIn=aProcessInstanceId,anotherProcessIns
         "processInstanceId": "aProcessInstanceId",
         "executionId": "b68b71c9-e310-11e2-beb0-f0def1557726",
         "taskId": null,
+        "batchId": null,
         "activityInstanceId": "Task_1:b68b71ca-e310-11e2-beb0-f0def1557726",
         "caseExecutionId": null,
         "caseInstanceId": null,
@@ -251,6 +261,7 @@ GET `/variable-instance?processInstanceIdIn=aProcessInstanceId,anotherProcessIns
         "processInstanceId": "aProcessInstanceId",
         "executionId": "68b71c9-e310-11e2-beb0-f0def1557726",
         "taskId": null,
+        "batchId": null,
         "activityInstanceId": "Task_1:b68b71ca-e310-11e2-beb0-f0def1557726",
         "caseExecutionId": null,
         "caseInstanceId": null,
@@ -267,6 +278,7 @@ GET `/variable-instance?processInstanceIdIn=aProcessInstanceId,anotherProcessIns
         "processInstanceId": "anotherProcessInstanceId",
         "executionId": "68b71c9-e310-11e2-beb0-f0def1557726",
         "taskId": null,
+        "batchId": null,
         "activityInstanceId": "Task_2:b68b71ca-e310-11e2-beb0-f0def1557726",
         "caseExecutionId": null,
         "caseInstanceId": null,

--- a/content/reference/rest/variable-instance/get.md
+++ b/content/reference/rest/variable-instance/get.md
@@ -117,6 +117,11 @@ A JSON object with the following properties:
     <td>The id of the task that this variable instance belongs to.</td>
   </tr>
   <tr>
+    <td>batchId</td>
+    <td>String</td>
+    <td>The id of the batch that this variable instance belongs to.<</td>
+  </tr>
+  <tr>
     <td>activityInstanceId</td>
     <td>String</td>
     <td>The id of the activity instance that this variable instance belongs to.</td>
@@ -173,6 +178,7 @@ Status 200.
       "processInstanceId": "aProcessInstanceId",
       "executionId": "b68b71c9-e310-11e2-beb0-f0def1557726",
       "taskId": null,
+      "batchId": null,
       "activityInstanceId": "Task_1:b68b71ca-e310-11e2-beb0-f0def1557726",
       "caseExecutionId": null,
       "caseInstanceId": null,

--- a/content/reference/rest/variable-instance/post-query-count.md
+++ b/content/reference/rest/variable-instance/post-query-count.md
@@ -61,6 +61,10 @@ A JSON object with the following properties:
     <td>Only include variable instances which belong to one of the passed task ids.</td>
   </tr>
   <tr>
+    <td>batchIdIn</td>
+    <td>Only include variable instances which belong to one of the passed batch ids.</td>
+  </tr>
+  <tr>
     <td>activityInstanceIdIn</td>
     <td>Only include variable instances which belong to one of the passed activity instance ids.</td>
   </tr>

--- a/content/reference/rest/variable-instance/post-query.md
+++ b/content/reference/rest/variable-instance/post-query.md
@@ -85,6 +85,10 @@ A JSON object with the following properties:
     <td>Only include variable instances which belong to one of the passed task ids.</td>
   </tr>
   <tr>
+    <td>batchIdIn</td>
+    <td>Only include variable instances which belong to one of the passed batch ids.</td>
+  </tr>
+  <tr>
     <td>activityInstanceIdIn</td>
     <td>Only include variable instances which belong to one of the passed activity instance ids.</td>
   </tr>
@@ -203,6 +207,11 @@ A JSON array of variable instance objects. Each variable instance object has the
     <td>The id of the task that this variable instance belongs to.</td>
   </tr>
   <tr>
+    <td>batchId</td>
+    <td>String</td>
+    <td>The id of the batch that this variable instance belongs to.</td>
+  </tr>
+  <tr>
     <td>activityInstanceId</td>
     <td>String</td>
     <td>The id of the activity instance that this variable instance belongs to.</td>
@@ -273,6 +282,7 @@ Request Body:
         "processInstanceId": "aProcessInstanceId",
         "executionId": "b68b71c9-e310-11e2-beb0-f0def1557726",
         "taskId": null,
+        "batchId": null,
         "activityInstanceId": "Task_1:b68b71ca-e310-11e2-beb0-f0def1557726",
         "serializationConfig": null,
         "tenantId": null
@@ -287,6 +297,7 @@ Request Body:
         "processInstanceId": "aProcessInstanceId",
         "executionId": "68b71c9-e310-11e2-beb0-f0def1557726",
         "taskId": null,
+        "batchId": null,
         "activityInstanceId": "Task_1:b68b71ca-e310-11e2-beb0-f0def1557726",
         "serializationConfig": null,
         "tenantId": null
@@ -301,6 +312,7 @@ Request Body:
         "processInstanceId": "anotherProcessInstanceId",
         "executionId": "68b71c9-e310-11e2-beb0-f0def1557726",
         "taskId": null,
+        "batchId": null,
         "activityInstanceId": "Task_2:b68b71ca-e310-11e2-beb0-f0def1557726",
         "serializationConfig": null,
         "tenantId": null


### PR DESCRIPTION
- Adds `batchIdIn` query criterion
- Adds `batchId` property to variable instance results

Related to CAM-12304