### PR TITLE
CAM-12097: chore(docs): create a single page for licence info

### DIFF
--- a/content/update/minor/712-to-713/_index.md
+++ b/content/update/minor/712-to-713/_index.md
@@ -167,7 +167,7 @@ If you want to set a license key without using the **`camunda-bpm-spring-boot-st
 ```java
 managementService.setLicenseKey(String licenseKey);
 ```
-Only Spring Boot applications that use one of the mentioned ways of setting the key are affected by these changes. Other mechanisms included in the engine (e.g. automatic pickup from the users home directory) are not affected. You can find more information about license keys in the [System Management Guide]({{< ref "/webapps/admin/system-management.md#camunda-license-key" >}}).
+Only Spring Boot applications that use one of the mentioned ways of setting the key are affected by these changes. Other mechanisms included in the engine (e.g. automatic pickup from the users home directory) are not affected. You can find more information about license keys in the [dedicated License use section]({{< ref "/user-guide/license-use.md" >}}).
 
 
 # External Task Client Update

--- a/content/user-guide/camunda-bpm-run.md
+++ b/content/user-guide/camunda-bpm-run.md
@@ -16,6 +16,7 @@ The idea behind Run is to provide a full Camunda BPM distro with a simple but po
 
 For a step-by-step installation guide head over to the [installation section]({{< ref "/installation/camunda-bpm-run.md" >}}) and get started in minutes.
 
+
 # Starting with Camunda BPM Run
 
 After downloading the [distro](https://downloads.camunda.cloud/release/camunda-bpm/run/) ([enterprise](https://downloads.camunda.cloud/enterprise-release/camunda-bpm/run/)) and unpacking it to a folder, you will find the following structure:
@@ -39,13 +40,19 @@ camunda-bpm-run
 ```
 Execute one of the two start scripts (`start.bat` for Windows, `start.sh` for Linux/Mac). After a few seconds, you will be able to access the Camunda webapps via http://localhost:8080/camunda/app/ and the REST API via http://localhost:8080/engine-rest/
 
+
 ## Starting Camunda BPM Run using Docker
+
 Camunda BPM Run is also available as a Docker image. Please see the Run section of the Camunda Docker documentation [here]({{< ref "/installation/docker.md#start-camunda-bpm-run-using-docker" >}}) for more details.
 
+
 ## Disable Webapps or REST API
+
 By default Camunda BPM Run launches with the webapps and REST API modules. If you want only one of them enabled, execute the start script with a command-line interface with a `--webapps` or `--rest` property to enable the specific module.
 
+
 ## Choose between default and production configuration
+
 Camunda BPM Run ships with two different configuration files which are both located in the `configuration` folder. 
 
 * The `default.yml` configuration only contains necessary configuration like the H2 database, a demo user and [CORS](#cross-origin-resource-sharing) for REST calls from a client application.
@@ -53,7 +60,9 @@ Camunda BPM Run ships with two different configuration files which are both loca
 
 By default Run launches with the `default.yml` configuration. To enable the `production.yml` configuration, execute the start script, through a command-line interface, with the `--production` property.
 
+
 ## Connect to a Database
+
 Camunda BPM Run is pre-configured to use a file-based H2 database for testing. The database schema and all required tables are automatically created when the engine starts up for the first time. If you want to use a custom standalone database, follow these steps:
 
 1. Make sure your database is among the [supported database systems]({{< ref "/introduction/supported-environments.md#supported-database-products" >}}).
@@ -63,17 +72,20 @@ Camunda BPM Run is pre-configured to use a file-based H2 database for testing. T
 1. Add the JDBC URL and login credentials to the configuration file like described [below](#database).
 1. Restart Camunda BPM Run
 
+
 ## Deploy BPMN Models
+
 In the unpacked distro, you will find a `resources` folder. All files (including BPMN, DMN, CMMN, form, and script files) will be deployed when you start Camunda BPM Run.
 
 Deployments via the [REST API]({{< ref "/reference/rest/deployment/post-deployment.md" >}}) are still possible.
 
+
 ## Automatic License Pickup
-If you downloaded the enterprise version of Camunda BPM Run, you will need a license key to enable the enterprise features.
 
-Provided a valid license file under `${user.home}/.camunda/license.txt`, Camunda BPM Run will automatically pick it up and use it to unlock the enterprise features.
+If you downloaded the enterprise version of Camunda BPM Run, you will need a license key to enable the enterprise 
+features. Please see the [dedicated License section]({{< ref "/user-guide/license-use.md#with-the-camunda-spring-boot-starter-camunda-run" >}}) 
+of the docs, to learn more.
 
-You can also still enter the license key in the Admin webapp UI.
 
 # Configure Camunda BPM Run
 
@@ -84,7 +96,9 @@ Camunda BPM Run is based on the [Camunda Spring Boot Starter](https://github.com
 All [configuration properties]({{< ref "/user-guide/spring-boot-integration/configuration.md#camunda-engine-properties" >}}) from the camunda-spring-boot-starter are available to customize Camunda BPM Run.
 {{< /note >}}
 
+
 ## Database
+
 The distro comes with a file-based h2 database for testing. It is recommended to connect to a standalone database system for use in production.
 
 <table class="table desc-table">
@@ -117,7 +131,9 @@ The distro comes with a file-based h2 database for testing. It is recommended to
   </tr>
 </table>
 
+
 ## Authentication
+
 To add authentication to requests against the [REST API]({{< ref "/reference/rest/overview/_index.md" >}}), you can enable basic authentication.
 
 <table class="table desc-table">
@@ -140,7 +156,9 @@ To add authentication to requests against the [REST API]({{< ref "/reference/res
   </tr>
 </table>
 
+
 ## Cross-Origin Resource Sharing
+
 If you want to allow cross-origin requests to the [REST API]({{< ref "/reference/rest/overview/_index.md" >}}), you need to enable CORS.
 <table class="table desc-table">
   <tr>
@@ -162,7 +180,9 @@ If you want to allow cross-origin requests to the [REST API]({{< ref "/reference
   </tr>
 </table>
 
+
 ## LDAP Identity Service
+
 Camunda BPM can manage users and authorizations on its own, but if you want to use an existing LDAP authentication database you can enable the [LDAP Identity Service Plugin]({{< ref "/user-guide/process-engine/identity-service.md#the-ldap-identity-service" >}})
 which provides read-only access to the LDAP repository.
 
@@ -183,7 +203,9 @@ Find all available configuration properties in the [LDAP Plugin Guide]({{< ref "
   </tr>
 </table>
 
+
 ## HTTPS
+
 Camunda BPM Run supports HTTPS over SSL. To enable it, you will need a valid SSL certificate signed by a trusted provider and stored in a key store file (either .jks or .p12).
 For testing, we included a self-signed certificate. You should not use this in production. To enable it, add the following properties to your configuration file.
 
@@ -234,7 +256,9 @@ After starting Camunda BPM Run, you can access the webapps via https://localhost
   </tr>
 </table>
 
+
 ## Logging
+
 Camunda BPM provides fine-grained and customizable logging. An overview of the available logging categories can be found in the [Logging User Guide]({{< ref "/user-guide/logging.md#process-engine" >}}).
 To configure the logging behavior in Camunda BPM Run, customize your configuration file with the following properties.
 

--- a/content/user-guide/license-use.md
+++ b/content/user-guide/license-use.md
@@ -1,0 +1,132 @@
+---
+
+title: 'Camunda License Keys'
+weight: 220
+
+menu:
+  main:
+    identifier: "user-guide-license"
+    parent: "user-guide"
+
+---
+
+Some Camunda BPM features (e.g. enterprise plugins) require a license key. The license will be provided as a string by 
+the Camunda support team. The license mechanism has no impact on the engine or other runtime components. The following 
+section explains the various methods by which a Camunda license can be added to the Process Engine.
+
+
+# Deployment Scenarios and the License Key
+
+A Camunda license key should be applied per database.
+
+In a clustered scenario, where multiple engines on multiple nodes access a single database, the 
+license only needs to be activated once. When activated, a license is valid until the expiration 
+date or until you have deleted your database. The license key is valid for an unlimited amount of 
+engines.
+
+In a multi tenancy scenario, the license check will be performed for each engine with an own 
+database. Thus, you will be prompted to enter the license key separately for each engine.
+
+
+# License Key Pickup Methods
+
+## Through the Admin Webapp UI
+
+Any environment setup that uses the enterprise Camunda Admin webapp, can use the provided License key page to
+enter a valid license key. Please see the dedicated [Admin webapp]({{< ref "/webapps/admin/system-management.md#camunda-license-key" >}}) 
+docs section for more details.
+
+## Through the Java API
+
+This method can be used in any environment setup. The license key can be set via the 
+Java API by calling:
+
+```
+managementService.setLicenseKey(String licenseKey);
+```
+
+The managementService also offers methods to get and delete the license key from the database.
+The license key is stored in the `ACT_GE_BYTEARRAY` table. A reference to the license entry can 
+be found in the `ACT_GE_PROPERTY` table (`camunda-license-key-id`).
+
+## Through the Home Directory
+
+Another possibility is to put a file with the license key on the path `${user.home}/.camunda/license.txt`. 
+This is another method that can be applied in any environment setup. The license key will be 
+automatically loaded in the database table unless a valid license key is already present.
+
+## With the Camunda Spring Boot Starter & Camunda Run
+
+Camunda Run, and other Spring Boot applications (including Camunda BPM RPA Bridge) that use the 
+Camunda Spring Boot Starter, can be provided with license  keys in two additional ways:
+
+* provide a URL to a license file via a custom [Spring Property]({{< ref "/user-guide/spring-boot-integration/configuration.md#license-file" >}}).
+* provide the license key in a file called `camunda-license.txt` which is on the classpath of the application.
+
+**Note:** For these two properties to be available, the Camunda Run EE edition must be used, or the Spring Boot 
+application must use the **`camunda-bpm-spring-boot-starter-webapp-ee`** module.
+
+```xml
+<dependency>
+  <groupId>org.camunda.bpm.springboot</groupId>
+  <artifactId>camunda-bpm-spring-boot-starter-webapp-ee</artifactId>
+</dependency>
+```
+
+# License compatibility
+
+There are two different types of licenses for Camunda BPM. While the original format is only valid 
+for Camunda BPM, the second format can be valid for multiple Camunda products (like Camunda BPM, 
+Cawemo or Optimize). Such unified licenses are supported from the versions listed below onwards. 
+Since 7.12.0 all versions (including major/minor releases) support unified license keys.
+
+<table class="table table-striped">
+  <tr>
+    <th>Camunda Engine version</th>
+    <th>Spring Boot Starter version</th>
+  </tr>
+  <tr>
+    <td>7.9.19+</td>
+    <td>3.0.8+</td>
+  </tr>
+  <tr>
+    <td>7.10.13+</td>
+    <td>3.1.8+<br>3.2.9+</td>
+  </tr>
+  <tr>
+    <td>7.11.7+</td>
+    <td>3.3.6+</td>
+  </tr>
+  <tr>
+    <td>7.12.x</td>
+    <td>3.4.x</td>
+  </tr>
+  <tr>
+    <td>7.13.0+</td>
+    <td>7.13.0+</td>
+  </tr>
+</table>
+
+
+# License content
+
+This section defines what is a valid license key that will be accepted by the Process Engine. This description is 
+valid for all [License pickup methods](#license-key-pickup-methods).
+
+A valid license key content should include the following:
+
+1. The header section:
+    ```
+    --------------- BEGIN CAMUNDA BPM LICENSE KEY ---------------
+    ``` 
+1. The encrypted license key.
+
+1. The unencrypted customer, expiry date and product data.
+
+1. The footer section:
+    ```
+    ---------------  END CAMUNDA BPM LICENSE KEY  ---------------
+    ```
+
+Note that omitting one of these sections will result in an error, and you will have to re-enter your
+license key in the correct format.

--- a/content/user-guide/spring-boot-integration/configuration.md
+++ b/content/user-guide/spring-boot-integration/configuration.md
@@ -276,7 +276,8 @@ The available properties are as follows:
   <li>from the file with the name <code>camunda-license.txt</code> from the classpath (if present)</li>
   <li>from path <i>${user.home}/.camunda/license.txt</i> (if present)</li>
  </ol>
- The license must be exactly in the format as we sent it to you including the header and footer line. Bear in mind that for some licenses there is a minimum <a href="{{<ref "/webapps/admin/system-management.md#license-compatibility" >}}">version requirement</a>.
+ The license must be exactly in the format as we sent it to you including the header and footer line. Bear in mind 
+ that for some licenses there is a minimum <a href="{{<ref "/user-guide/license-use.md#license-compatibility" >}}">version requirement</a>.
 </td>
 </tr>
 

--- a/content/user-guide/spring-boot-integration/webapps.md
+++ b/content/user-guide/spring-boot-integration/webapps.md
@@ -36,7 +36,10 @@ To use the enterprise Web applications, include another starter:
 
 Also don't forget to define the appropriate Camunda engine version (with "ee" suffix): see [Using Enterprise Edition](../#using-enterprise-edition).
 
-If you are using the enterprise edition, you can also use the [`camunda.bpm.license-file`]({{<ref "/user-guide/spring-boot-integration/configuration.md#license-file">}}) property to provide a license file that is inserted on application start. Or copy your license file under the name `camunda-license.txt` to your `src/main/resources`.
+If you are using the enterprise edition, you can also use the [`camunda.bpm.license-file`]({{<ref "/user-guide/spring-boot-integration/configuration.md#license-file">}}) 
+property to provide a license file that is inserted on application start. Or copy your license file under the name 
+`camunda-license.txt` to your `src/main/resources`. See the dedicated [License docs section]({{< ref "/user-guide/license-use.md" >}})
+for more details on how to add a License key to your Camunda installation.
 
 ## Configurations
 

--- a/content/webapps/admin/system-management.md
+++ b/content/webapps/admin/system-management.md
@@ -31,17 +31,23 @@ processed by the engine within a specified time range.
 # Camunda License Key
 
 {{< enterprise >}}
-  Please note that this feature is only included in the enterprise edition of the Camunda BPM platform, it is not available in the community edition.
+  Please note that this feature is only included in the enterprise edition of the Camunda BPM platform, it is not 
+  available in the community edition.
 {{< /enterprise >}}
 
-Some features (enterprise plugins) require a license key. The license will be provided as a string by the Camunda support team. The license mechanism has no impact on the engine or other runtime components. The following section explains how to activate a license.
+Some features of the Camunda Webapps (e.g. enterprise plugins) require a license key. To read more about the Camunda
+license key, please see the [dedicated section]({{< ref "/user-guide/license-use.md" >}}) of the docs. The following 
+section explains how to activate a license through the Camunda Admin Webapp UI.
 
 Whenever you see one of the following messages, a valid license key must be entered.
 
 {{< img src="../img/admin-license-prompt.png" title="License Prompt for Admins" >}}
 {{< img src="../img/admin-license-prompt-noAdmin.png" title="License Prompt for Non-Admins" >}}
 
-If you have administrator authorizations, insert your company's license key for the Camunda BPM platform and view some License Key details such as the Company Id and the validity of the license key. The Admin system setting menu offers the possibility to enter additional licenses, for instance when your existing license is expiring and you want to enter a new license key.
+If you have administrator authorizations, insert your company's license key for the Camunda BPM platform and view 
+some License Key details such as the Company Id and the validity of the license key. The Admin system setting menu 
+offers the possibility to enter additional licenses, for instance when your existing license is expiring and you want 
+to enter a new license key.
 
 If you do not have administrator authorizations, please contact your administrator so that they can enter the license.
 
@@ -49,60 +55,3 @@ In case you are running Camunda BPM locally, you can use this URL to enter the l
 http://localhost:8080/camunda/app/admin/default/#/system?section=system-settings-license
 
 {{< img src="../img/admin-license-key.png" title="License Key" >}}
-
-The license key can be set via the Java API by calling:
-```
-managementService.setLicenseKey(String licenseKey);
-```
-The managementService also offers methods to get and delete the license key from the database.
-The license key is stored in the `ACT_GE_BYTEARRAY` table. A reference to the license entry can be found in the `ACT_GE_PROPERTY` table (`camunda-license-key-id`).
-
-Another possibility is to put the file with the license key in path: `${user.home}/.camunda/license.txt`. It will be automatically loaded to the database table unless it already contains some license key.
-
-In a clustered scenario, where multiple engines on multiple nodes access a single database, the license only needs to be activated once. When activated, a license is valid until the expiration date or until you have deleted your database. The license key is valid for an unlimited amount of engines.
-
-In a multi tenancy scenario, the license check will be performed for each engine with an own database. Thus, you will be prompted to enter the license key separately for each engine.
-
-## License keys in camunda-spring-boot-starter
-Spring Boot applications can provide license keys in two additional ways:
-
-* provide a URL to a license file via [spring property]({{< ref "/user-guide/spring-boot-integration/configuration.md#license-file" >}})
-* provide the license key in a file called `camunda-license.txt` which is on the classpath of the application
-
-**Note:** The application must use the **`camunda-bpm-spring-boot-starter-webapp-ee`** module for these two properties to be available.
-```xml
-<dependency>
-  <groupId>org.camunda.bpm.springboot</groupId>
-  <artifactId>camunda-bpm-spring-boot-starter-webapp-ee</artifactId>
-</dependency>
-```
-
-## License compatibility
-There are two different types of licenses for Camunda BPM. While the original format is only valid for Camunda BPM, the second format can be valid for multiple Camunda products (like Camunda BPM, Cawemo or Optimize). Such unified licenses are supported from the versions listed below onwards. Since 7.12.0 all versions (including major/minor releases) support unified license keys.
-
-<table class="table table-striped">
-  <tr>
-    <th>Camunda Engine version</th>
-    <th>Spring Boot Starter version</th>
-  </tr>
-  <tr>
-    <td>7.9.19+</td>
-    <td>3.0.8+</td>
-  </tr>
-  <tr>
-    <td>7.10.13+</td>
-    <td>3.1.8+<br>3.2.9+</td>
-  </tr>
-  <tr>
-    <td>7.11.7+</td>
-    <td>3.3.6+</td>
-  </tr>
-  <tr>
-    <td>7.12.x</td>
-    <td>3.4.x</td>
-  </tr>
-  <tr>
-    <td>7.13.0+</td>
-    <td>7.13.0+</td>
-  </tr>
-</table>


### PR DESCRIPTION
* Add a single page dedicated to the Camunda License usage and retrieval
  methods.
* Adjust the doc sections where License use is described to point to the
  dedicated License page.

Related to CAM-12097