### PR TITLE
add backoff description

### DIFF
--- a/content/user-guide/process-engine/the-job-executor.md
+++ b/content/user-guide/process-engine/the-job-executor.md
@@ -366,7 +366,7 @@ For example:
 
 ## Backoff Strategy
 The Job Executor uses a backoff strategy to avoid acquisition conflicts in clusters and to reduce the database load when no jobs are due. The second point may result in a delay between job creation and job execution as the job acquisition by default doubles the delay to the next acquisition run. 
-The default maximum wait time to set to 60 seconds. You can decrease the delay by setting the configuration parameter `maxWait` to a value lower than 60000 milliseconds.
+The default maximum wait time is 60 seconds. You can decrease the delay by setting the configuration parameter `maxWait` to a value lower than 60000 milliseconds.
 
 # Job Execution
 

--- a/content/user-guide/process-engine/the-job-executor.md
+++ b/content/user-guide/process-engine/the-job-executor.md
@@ -365,7 +365,7 @@ For example:
 </table>
 
 ## Backoff Strategy
-The Job Executor uses a backoff strategy to avoid acquisition conflicts in clusters and to reduce the database load when no jobs are due. The second point may result in a delay between job creation and job execution as the job aquisition by default doubles the delay to the next acquisition run. 
+The Job Executor uses a backoff strategy to avoid acquisition conflicts in clusters and to reduce the database load when no jobs are due. The second point may result in a delay between job creation and job execution as the job acquisition by default doubles the delay to the next acquisition run. 
 The default maximum wait time to set to 60 seconds. You can decrease the delay by setting the configuration parameter `maxWait` to a value lower than 60000 milliseconds.
 
 # Job Execution

--- a/content/user-guide/process-engine/the-job-executor.md
+++ b/content/user-guide/process-engine/the-job-executor.md
@@ -364,7 +364,9 @@ For example:
   </tr>
 </table>
 
-
+## Backoff Strategy
+The Job Executor uses a backoff strategy to avoid acquisition conflicts in clusters and to reduce the database load when no jobs are due. The second point may result in a delay between job creation and job execution as the job aquisition by default doubles the delay to the next acquisition run. 
+The default maximum wait time to set to 60 seconds. You can decrease the delay by setting the configuration parameter `maxWait` to a value lower than 60000 milliseconds.
 
 # Job Execution
 


### PR DESCRIPTION
as many forum question like this: https://forum.camunda.org/t/job-executor-taking-longer-time-to-complete/22723 came along it is worth to mention the backoff in the docs.