### PR TITLE
add a hint to findId(activityName)

### DIFF
--- a/content/user-guide/testing/_index.md
+++ b/content/user-guide/testing/_index.md
@@ -167,6 +167,7 @@ Additional to normal JUnit assertions, [Camunda BPM Assert](https://github.com/c
 
 ```java
 assertThat(processInstance).isWaitingAt("UserTask_InformCustomer");
+assertThat(processInstance).isWaitingAt(findId("My task name"));
 assertThat(task()).hasCandidateGroup("Sales").isNotAssigned();
 ```
 


### PR DESCRIPTION
To introduce `findId()` in the developer training it would be nice to have an example here. 
We are referencing this section from the training exercise.