### PR TITLE
CAM-12679: fix Camunda BPM Run logging properties

### DIFF
--- a/content/user-guide/camunda-bpm-run.md
+++ b/content/user-guide/camunda-bpm-run.md
@@ -284,7 +284,7 @@ For more information on logging configuration visit the [Spring Boot Logging Gui
       <td><code>-</code></td>
   </tr>
   <tr>
-      <td><code>.file</code></td>
+      <td><code>.file.name</code></td>
       <td>Specify a log file location. (e.g. <code>logs/camunda-bpm-run-log.txt</code>)</td>
       <td><code>-</code></td>
   </tr>


### PR DESCRIPTION
depending on: https://github.com/camunda/camunda-bpm-platform/pull/1156

Maybe we should also considering to remove the link to https://howtodoinjava.com/spring-boot2/logging/configure-logging-application-yml. Because there is also the old property described.