### PR TITLE
CAM-13095: mention business key on process start

### DIFF
--- a/content/reference/rest/message/post-message.md
+++ b/content/reference/rest/message/post-message.md
@@ -39,7 +39,7 @@ A JSON object with the following properties:
   </tr>
   <tr>
     <td>businessKey</td>
-    <td>Used for correlation of process instances that wait for incoming messages. Will only correlate to executions that belong to a process instance with the provided business key.</td>
+    <td>Used for correlation of process instances that wait for incoming messages. Will only correlate to executions that belong to a process instance with the provided business key.<br>If the message triggers a start, the business key is set in the process instance.</td>
   </tr>
   <tr>
     <td>tenantId</td>

--- a/content/reference/rest/message/post-message.md
+++ b/content/reference/rest/message/post-message.md
@@ -39,7 +39,7 @@ A JSON object with the following properties:
   </tr>
   <tr>
     <td>businessKey</td>
-    <td>Used for correlation of process instances that wait for incoming messages. Will only correlate to executions that belong to a process instance with the provided business key.<br>If the message triggers a start, the business key is set in the process instance.</td>
+    <td>Used for correlation of process instances that wait for incoming messages. Will only correlate to executions that belong to a process instance with the provided business key.<br>If the message triggers a start event, the business key is set in the process instance.</td>
   </tr>
   <tr>
     <td>tenantId</td>


### PR DESCRIPTION
Add a hint that the business key will be set triggering a message start event.