### PR TITLE
[CAM-13161] chore(connect): correct path to ConnectorConfigurator

### DIFF
--- a/content/reference/connect/http-connector.md
+++ b/content/reference/connect/http-connector.md
@@ -58,7 +58,7 @@ public class HttpConnectorConfigurator implements ConnectorConfigurator<HttpConn
 ```
 
 To enable auto detection of your new configurator please add a file called
-`org.camunda.bpm.connect.spi.ConnectorConfigurator` to your
+`org.camunda.connect.spi.ConnectorConfigurator` to your
 `resources/META-INF/services` directory with class name as content. For more
 information see the [extending Connect]({{< ref "/reference/connect/extending-connect.md" >}}) section.
 


### PR DESCRIPTION
The file name is correct in the provided link `extending Connect` 

using version 7.14.0