### PR TITLE
docs(rest): add valueNotLike filter for tasks

### DIFF
--- a/content/reference/rest/history/task/get-task-query-count.md
+++ b/content/reference/rest/history/task/get-task-query-count.md
@@ -250,7 +250,7 @@ GET `/history/task/count`
     <br/>
     Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to; <code>gt</code> - greater than;
     <code>gteq</code> - greater than or equal to; <code>lt</code> - lower than; <code>lteq</code> - lower than or equal to;
-    <code>like</code>.<br/>
+    <code>like</code>;<code>notLike</code>.<br/>
     <code>key</code> and <code>value</code> may not contain underscore or comma characters.
     </td>
   </tr>

--- a/content/reference/rest/history/task/get-task-query.md
+++ b/content/reference/rest/history/task/get-task-query.md
@@ -250,7 +250,7 @@ GET `/history/task`
     <br/>
     Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to; <code>gt</code> - greater than;
     <code>gteq</code> - greater than or equal to; <code>lt</code> - lower than; <code>lteq</code> - lower than or equal to;
-    <code>like</code>.<br/>
+    <code>like</code>;<code>notLike</code>.<br/>
     <code>key</code> and <code>value</code> may not contain underscore or comma characters.
     </td>
   </tr>

--- a/content/reference/rest/history/task/post-task-query-count.md
+++ b/content/reference/rest/history/task/post-task-query-count.md
@@ -251,7 +251,7 @@ A JSON object with the following properties:
     <br/>
     Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to; <code>gt</code> - greater than;
     <code>gteq</code> - greater than or equal to; <code>lt</code> - lower than; <code>lteq</code> - lower than or equal to;
-    <code>like</code>.<br/>
+    <code>like</code>;<code>notLike</code>.<br/>
     </td>
   </tr>
   <tr>

--- a/content/reference/rest/history/task/post-task-query.md
+++ b/content/reference/rest/history/task/post-task-query.md
@@ -270,7 +270,7 @@ A JSON object with the following properties:
     <br/>
     Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to; <code>gt</code> - greater than;
     <code>gteq</code> - greater than or equal to; <code>lt</code> - lower than; <code>lteq</code> - lower than or equal to;
-    <code>like</code>.<br/>
+    <code>like</code>;<code>notLike</code>.<br/>
     </td>
   </tr>
   <tr>

--- a/content/reference/rest/task/get-query-count.md
+++ b/content/reference/rest/task/get-query-count.md
@@ -486,7 +486,7 @@ GET `/task/count`
     <br/>
    Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to; <code>gt</code> - greater than;
     <code>gteq</code> - greater than or equal to; <code>lt</code> - lower than; <code>lteq</code> - lower than or equal to;
-    <code>like</code>.<br/>
+    <code>like</code>;<code>notLike</code>.<br/>
     <code>key</code> and <code>value</code> may not contain underscore or comma characters.
     </td>
   </tr>

--- a/content/reference/rest/task/get-query.md
+++ b/content/reference/rest/task/get-query.md
@@ -488,7 +488,7 @@ GET `/task`
     <br/>
     Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to; <code>gt</code> - greater than;
     <code>gteq</code> - greater than or equal to; <code>lt</code> - lower than; <code>lteq</code> - lower than or equal to;
-    <code>like</code>.<br/>
+    <code>like</code>;<code>notLike</code>.<br/>
     <code>key</code> and <code>value</code> may not contain underscore or comma characters.
     </td>
   </tr>

--- a/content/reference/rest/task/post-query-count.md
+++ b/content/reference/rest/task/post-query-count.md
@@ -485,7 +485,7 @@ expression as a substring.
     <br/>
     Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to; <code>gt</code> - greater than;
     <code>gteq</code> - greater than or equal to; <code>lt</code> - lower than; <code>lteq</code> - lower than or equal to;
-    <code>like</code>.<br/>
+    <code>like</code>;<code>notLike</code>.<br/>
     </td>
   </tr>
   <tr>

--- a/content/reference/rest/task/post-query.md
+++ b/content/reference/rest/task/post-query.md
@@ -505,7 +505,7 @@ A JSON object with the following properties:
     <br/>
     Valid operator values are: <code>eq</code> - equal to; <code>neq</code> - not equal to; <code>gt</code> - greater than;
     <code>gteq</code> - greater than or equal to; <code>lt</code> - lower than; <code>lteq</code> - lower than or equal to;
-    <code>like</code>.<br/>
+    <code>like</code>;<code>notLike</code>.<br/>
     </td>
   </tr>
   <tr>


### PR DESCRIPTION
* adds query option to filter for (historic) tasks that do not have a variable
  with a value like the given one

related to CAM-13173