### PR TITLE
chore(user-guide): add general external task error events

### DIFF
--- a/content/reference/bpmn20/events/error-events.md
+++ b/content/reference/bpmn20/events/error-events.md
@@ -80,6 +80,21 @@ The referencing error event definition must specify <a href="{{< ref "/reference
 ```
 When the error thrown by the error end event is catched a process variable with the name `err` will be created that holds the evaluated message.
 
+For External Tasks, it is also possible to define error events by using a [camunda:errorEventDefinition]({{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#erroreventdefinition" >}}) as shown in the following example. It additionally requires an expression that must evaluate to `true` in order for the BPMN error to be thrown. For further details on how to use those error events, consult the [External Tasks Guide]({{< ref "/user-guide/process-engine/external-tasks.md#error-event-definitions" >}}).
+
+```xml
+<serviceTask id="validateAddressTask"
+  name="Validate Address"
+  camunda:type="external"
+  camunda:topic="AddressValidation" >
+  <extensionElements>
+    <camunda:errorEventDefinition id="addressErrorDefinition" 
+      errorRef="addressError" 
+      expression="${externalTask.getErrorDetails().contains('address error found')}" />
+  </extensionElements>
+</serviceTask>
+```
+
 # Error Start Event
 
 An error start event can only be used to trigger an Event Sub-Process - it __cannot__ be used to start a process instance. The error start event is always interrupting.

--- a/content/user-guide/camunda-bpm-rpa-bridge.md
+++ b/content/user-guide/camunda-bpm-rpa-bridge.md
@@ -322,7 +322,8 @@ The bot might return more variables which will be ignored in this case.
 
 In the case that not everything works as expected and an RPA bot fails for any reason, you might want to react to the failure by throwing a BPMN error.
 You can do that by adding the [camunda:errorEventDefinition]({{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#erroreventdefinition" >}}) extension element.
-Note that compared to the `bpmn:errorEventDefinition`, `camunda:errorEventDefinition` elements accept an additional `expression` attribute which supports any JUEL expression. Additionally, within the expression you have access to the externalTaskEntity object like shown in the example below. For more information about External Task error handling via `camunda:errorEventDefinition` have a look into the [expression language user guide]({{< ref "/user-guide/process-engine/expression-language.md#external-task-error-handling" >}})
+
+Compared to the `bpmn:errorEventDefinition`, the `camunda:errorEventDefinition` elements accept an additional `expression` attribute which supports any JUEL expression. Within the expression you have access to the `ExternalTaskEntity` object like shown in the example below. For more information about External Task error handling via `camunda:errorEventDefinition` have a look at the [External Tasks Guide]({{< ref "/user-guide/process-engine/external-tasks.md#error-event-definitions" >}}).
 
 You can use this feature regardless of the outcome of the RPA bot. Even if the bot was executed successfully, you can still decide to throw a BPMN error. Also note, that
 the RPA bots variables are available for mapping and error handling via `camunda:errorEventDefinition` as well even if the bot failed.

--- a/content/user-guide/process-engine/expression-language.md
+++ b/content/user-guide/process-engine/expression-language.md
@@ -181,14 +181,13 @@ a bean.
 
 ## External Task Error Handling
 
-For External Tasks (including tasks handled by [Camunda Platform RPA Bridge]({{< ref "/user-guide/camunda-bpm-rpa-bridge.md" >}})) it is possible to define
+For External Tasks it is possible to define
 [camunda:errorEventDefinition]({{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#erroreventdefinition" >}})
-elements which can be provided with a JUEL expression. The expression is evaluated on `externalTask.complete()` and
-`externalTask.failed()`. If the expression evaluates to true a BPMN error is thrown which can be caught by an
+elements which can be provided with a JUEL expression. The expression is evaluated on `ExternalTaskService#complete` and
+`ExternalTaskService#handleFailure`. If the expression evaluates to `true`, a BPMN error is thrown which can be caught by an
 [Error Boundary Event]({{< ref "/reference/bpmn20/events/error-events.md#error-boundary-event" >}}).
 
-In the scope of an External Task, expressions have access to the {{< javadocref page="?org/camunda/bpm/engine/externaltask/ExternalTask.html" text="ExternalTaskEntity" >}} object via the key `externalTask` which provides getter methods
-for `errorMessage`, `errorDetails`, `workerId`, `retries` and more.
+In the scope of an External Task, expressions have access to the {{< javadocref page="?org/camunda/bpm/engine/externaltask/ExternalTask.html" text="ExternalTaskEntity" >}} object via the key `externalTask` which provides getter methods for `errorMessage`, `errorDetails`, `workerId`, `retries` and more.
 
 **Examples:**
 
@@ -212,6 +211,7 @@ How to match an error message:
 </bpmn:serviceTask>
 ```
 
+For further details on the functionality of error event definitions in the context of external tasks, consult the [External Tasks Guide]({{< ref "/user-guide/process-engine/external-tasks.md#error-event-definitions" >}}).
 
 ## Value
 


### PR DESCRIPTION
* adds a general explanation of error event definitions on external tasks
  and reuses the section in referring pages

related to CAM-13248