### PR TITLE
Documentation Fix

### DIFF
--- a/content/user-guide/process-engine/variables.md
+++ b/content/user-guide/process-engine/variables.md
@@ -477,8 +477,8 @@ Input mappings can also be used with multi-instance constructs, in which the map
 {{< /note >}}
 
 [inputOutput]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#camunda-inputoutput" >}}
-[inputParameter]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements/#inputparameter" >}}
-[outputParameter]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements/#outputparameter" >}}
+[inputParameter]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#inputparameter" >}}
+[outputParameter]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#outputparameter" >}}
 [list]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#camunda-list" >}}
 [map]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#camunda-map" >}}
 [script-io]: {{< ref "/user-guide/process-engine/scripting.md#use-scripts-as-inputoutput-parameters" >}}

--- a/content/user-guide/process-engine/variables.md
+++ b/content/user-guide/process-engine/variables.md
@@ -477,8 +477,8 @@ Input mappings can also be used with multi-instance constructs, in which the map
 {{< /note >}}
 
 [inputOutput]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#camunda-inputoutput" >}}
-[inputParameter]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#camunda-inputparameter" >}}
-[outputParameter]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#camunda-outputparameter" >}}
+[inputParameter]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements/#inputparameter" >}}
+[outputParameter]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements/#outputparameter" >}}
 [list]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#camunda-list" >}}
 [map]: {{< ref "/reference/bpmn20/custom-extensions/extension-elements.md#camunda-map" >}}
 [script-io]: {{< ref "/user-guide/process-engine/scripting.md#use-scripts-as-inputoutput-parameters" >}}


### PR DESCRIPTION
Given link is not landing to the section of the page where it is intended to i.e. "inputParameter" & "outputParamter" section in particular on the extension elements page. So taking this change would land exactly the same section on the page where its referred to.