### PR TITLE
Fix a section title in docs (external tasks).

### DIFF
--- a/content/reference/rest/external-task/post-unlock.md
+++ b/content/reference/rest/external-task/post-unlock.md
@@ -1,6 +1,6 @@
 ---
 
-title: 'Handle External Task Failure'
+title: 'Unlock External Task'
 weight: 110
 
 menu:


### PR DESCRIPTION
Just a small correction. Title was probably copied from another document.