### PR TITLE
CAM-13303: fix(bpmn): adjust inclusive gateway limitations

### DIFF
--- a/content/reference/bpmn20/gateways/bpmn/inclusive_gateway_scenario_1.bpmn
+++ b/content/reference/bpmn20/gateways/bpmn/inclusive_gateway_scenario_1.bpmn
@@ -1,122 +1,143 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_05im1mb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
-  <bpmn:process id="Process_1c7tz3b" isExecutable="true">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_14bot2c" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+  <bpmn:process id="Process_0544qac" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1" name="Start Event">
-      <bpmn:outgoing>Flow_19irolq</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1q5l3vt</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_19irolq" sourceRef="StartEvent_1" targetRef="Gateway_13lt6dh" />
-    <bpmn:parallelGateway id="Gateway_13lt6dh" name="Parallel Gateway">
-      <bpmn:incoming>Flow_19irolq</bpmn:incoming>
-      <bpmn:outgoing>Flow_1te8lpw</bpmn:outgoing>
-      <bpmn:outgoing>Flow_0awrz86</bpmn:outgoing>
-      <bpmn:outgoing>Flow_1tbliw8</bpmn:outgoing>
+    <bpmn:sequenceFlow id="Flow_1q5l3vt" sourceRef="StartEvent_1" targetRef="Gateway_01lr1h0" />
+    <bpmn:exclusiveGateway id="Gateway_17h3kle" name="Exclusive Gateway">
+      <bpmn:incoming>Flow_1u5ensc</bpmn:incoming>
+      <bpmn:incoming>Flow_1vmdlrp</bpmn:incoming>
+      <bpmn:outgoing>Flow_0b46o2y</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_1u5ensc" sourceRef="Gateway_01lr1h0" targetRef="Gateway_17h3kle" />
+    <bpmn:sequenceFlow id="Flow_08amosu" sourceRef="Gateway_01lr1h0" targetRef="Activity_1xm8iag" />
+    <bpmn:sequenceFlow id="Flow_1vmdlrp" sourceRef="Activity_1xm8iag" targetRef="Gateway_17h3kle" />
+    <bpmn:sequenceFlow id="Flow_0b46o2y" sourceRef="Gateway_17h3kle" targetRef="Gateway_10bz2ml" />
+    <bpmn:sequenceFlow id="Flow_1pwvprk" name="true" sourceRef="Gateway_10bz2ml" targetRef="Gateway_1kmkcqg">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${true}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_15yltuq" name="End Event">
+      <bpmn:incoming>Flow_147pt49</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_017qwte" sourceRef="Gateway_1kmkcqg" targetRef="Activity_1bz28eq" />
+    <bpmn:parallelGateway id="Gateway_01lr1h0" name="Parallel Gateway">
+      <bpmn:incoming>Flow_1q5l3vt</bpmn:incoming>
+      <bpmn:outgoing>Flow_1u5ensc</bpmn:outgoing>
+      <bpmn:outgoing>Flow_08amosu</bpmn:outgoing>
     </bpmn:parallelGateway>
-    <bpmn:sequenceFlow id="Flow_1te8lpw" sourceRef="Gateway_13lt6dh" targetRef="Activity_11ix1dc" />
-    <bpmn:inclusiveGateway id="Gateway_0j3r3jo" name="Inclusive Gateway">
-      <bpmn:incoming>Flow_06etm8o</bpmn:incoming>
-      <bpmn:incoming>Flow_07xmcx4</bpmn:incoming>
-      <bpmn:outgoing>Flow_19q4uat</bpmn:outgoing>
+    <bpmn:inclusiveGateway id="Gateway_10bz2ml" name="Inclusive Gateway 1">
+      <bpmn:incoming>Flow_0b46o2y</bpmn:incoming>
+      <bpmn:outgoing>Flow_1pwvprk</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0x9yhc9</bpmn:outgoing>
     </bpmn:inclusiveGateway>
-    <bpmn:endEvent id="Event_1qau71j" name="End Event 1">
-      <bpmn:incoming>Flow_19q4uat</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_19q4uat" sourceRef="Gateway_0j3r3jo" targetRef="Event_1qau71j" />
-    <bpmn:sequenceFlow id="Flow_0awrz86" sourceRef="Gateway_13lt6dh" targetRef="Activity_16o3zb7" />
-    <bpmn:endEvent id="Event_18ybdgd" name="End Event 2">
-      <bpmn:incoming>Flow_1iqu0j0</bpmn:incoming>
-    </bpmn:endEvent>
-    <bpmn:sequenceFlow id="Flow_1iqu0j0" sourceRef="Activity_16o3zb7" targetRef="Event_18ybdgd" />
-    <bpmn:sequenceFlow id="Flow_1tbliw8" sourceRef="Gateway_13lt6dh" targetRef="Activity_1if0inu" />
-    <bpmn:sequenceFlow id="Flow_06etm8o" sourceRef="Activity_1if0inu" targetRef="Gateway_0j3r3jo" />
-    <bpmn:task id="Activity_1if0inu" name="Task 1">
-      <bpmn:incoming>Flow_1tbliw8</bpmn:incoming>
-      <bpmn:outgoing>Flow_06etm8o</bpmn:outgoing>
-    </bpmn:task>
-    <bpmn:task id="Activity_16o3zb7" name="Task 3">
-      <bpmn:incoming>Flow_0awrz86</bpmn:incoming>
-      <bpmn:outgoing>Flow_1iqu0j0</bpmn:outgoing>
-    </bpmn:task>
-    <bpmn:task id="Activity_11ix1dc" name="Task 2">
-      <bpmn:incoming>Flow_1te8lpw</bpmn:incoming>
-      <bpmn:outgoing>Flow_07xmcx4</bpmn:outgoing>
-    </bpmn:task>
-    <bpmn:sequenceFlow id="Flow_07xmcx4" sourceRef="Activity_11ix1dc" targetRef="Gateway_0j3r3jo" />
+    <bpmn:inclusiveGateway id="Gateway_1kmkcqg" name="Inclusive Gateway 2">
+      <bpmn:incoming>Flow_1pwvprk</bpmn:incoming>
+      <bpmn:incoming>Flow_0x9yhc9</bpmn:incoming>
+      <bpmn:outgoing>Flow_017qwte</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_0x9yhc9" name="false" sourceRef="Gateway_10bz2ml" targetRef="Gateway_1kmkcqg">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">${false}</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:userTask id="Activity_1xm8iag" name="User Task 1">
+      <bpmn:incoming>Flow_08amosu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1vmdlrp</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_147pt49" sourceRef="Activity_1bz28eq" targetRef="Event_15yltuq" />
+    <bpmn:userTask id="Activity_1bz28eq" name="User Task 2">
+      <bpmn:incoming>Flow_017qwte</bpmn:incoming>
+      <bpmn:outgoing>Flow_147pt49</bpmn:outgoing>
+    </bpmn:userTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
-    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1c7tz3b">
-      <bpmndi:BPMNEdge id="Flow_19irolq_di" bpmnElement="Flow_19irolq">
-        <di:waypoint x="198" y="260" />
-        <di:waypoint x="305" y="260" />
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0544qac">
+      <bpmndi:BPMNEdge id="Flow_0x9yhc9_di" bpmnElement="Flow_0x9yhc9">
+        <di:waypoint x="670" y="292" />
+        <di:waypoint x="670" y="370" />
+        <di:waypoint x="870" y="370" />
+        <di:waypoint x="870" y="292" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="758" y="352" width="24" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1te8lpw_di" bpmnElement="Flow_1te8lpw">
-        <di:waypoint x="355" y="260" />
-        <di:waypoint x="390" y="260" />
+      <bpmndi:BPMNEdge id="Flow_017qwte_di" bpmnElement="Flow_017qwte">
+        <di:waypoint x="895" y="267" />
+        <di:waypoint x="940" y="267" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_19q4uat_di" bpmnElement="Flow_19q4uat">
-        <di:waypoint x="585" y="260" />
-        <di:waypoint x="672" y="260" />
+      <bpmndi:BPMNEdge id="Flow_1pwvprk_di" bpmnElement="Flow_1pwvprk">
+        <di:waypoint x="695" y="267" />
+        <di:waypoint x="845" y="267" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="761" y="249" width="19" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0awrz86_di" bpmnElement="Flow_0awrz86">
-        <di:waypoint x="330" y="285" />
-        <di:waypoint x="330" y="390" />
-        <di:waypoint x="390" y="390" />
+      <bpmndi:BPMNEdge id="Flow_0b46o2y_di" bpmnElement="Flow_0b46o2y">
+        <di:waypoint x="555" y="267" />
+        <di:waypoint x="645" y="267" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1iqu0j0_di" bpmnElement="Flow_1iqu0j0">
-        <di:waypoint x="490" y="390" />
-        <di:waypoint x="672" y="390" />
+      <bpmndi:BPMNEdge id="Flow_1vmdlrp_di" bpmnElement="Flow_1vmdlrp">
+        <di:waypoint x="460" y="120" />
+        <di:waypoint x="530" y="120" />
+        <di:waypoint x="530" y="242" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1tbliw8_di" bpmnElement="Flow_1tbliw8">
-        <di:waypoint x="330" y="235" />
-        <di:waypoint x="330" y="120" />
-        <di:waypoint x="390" y="120" />
+      <bpmndi:BPMNEdge id="Flow_08amosu_di" bpmnElement="Flow_08amosu">
+        <di:waypoint x="290" y="242" />
+        <di:waypoint x="290" y="120" />
+        <di:waypoint x="360" y="120" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06etm8o_di" bpmnElement="Flow_06etm8o">
-        <di:waypoint x="490" y="120" />
-        <di:waypoint x="560" y="120" />
-        <di:waypoint x="560" y="235" />
+      <bpmndi:BPMNEdge id="Flow_1u5ensc_di" bpmnElement="Flow_1u5ensc">
+        <di:waypoint x="315" y="267" />
+        <di:waypoint x="505" y="267" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_07xmcx4_di" bpmnElement="Flow_07xmcx4">
-        <di:waypoint x="490" y="260" />
-        <di:waypoint x="535" y="260" />
+      <bpmndi:BPMNEdge id="Flow_1q5l3vt_di" bpmnElement="Flow_1q5l3vt">
+        <di:waypoint x="215" y="267" />
+        <di:waypoint x="265" y="267" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_147pt49_di" bpmnElement="Flow_147pt49">
+        <di:waypoint x="1040" y="267" />
+        <di:waypoint x="1112" y="267" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="162" y="242" width="36" height="36" />
+        <dc:Bounds x="179" y="249" width="36" height="36" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="153" y="285" width="55" height="14" />
+          <dc:Bounds x="170" y="292" width="55" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_0a9jxqv_di" bpmnElement="Gateway_0j3r3jo">
-        <dc:Bounds x="535" y="235" width="50" height="50" />
+      <bpmndi:BPMNShape id="Gateway_17h3kle_di" bpmnElement="Gateway_17h3kle" isMarkerVisible="true">
+        <dc:Bounds x="505" y="242" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="515" y="292" width="90" height="14" />
+          <dc:Bounds x="507" y="299" width="47" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_1qau71j_di" bpmnElement="Event_1qau71j">
-        <dc:Bounds x="672" y="242" width="36" height="36" />
+      <bpmndi:BPMNShape id="Gateway_0kr0bfa_di" bpmnElement="Gateway_01lr1h0">
+        <dc:Bounds x="265" y="242" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="660" y="285" width="60" height="14" />
+          <dc:Bounds x="248" y="299" width="84" height="14" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Gateway_09vjvnl_di" bpmnElement="Gateway_13lt6dh">
-        <dc:Bounds x="305" y="235" width="50" height="50" />
+      <bpmndi:BPMNShape id="Activity_1p16p2s_di" bpmnElement="Activity_1xm8iag">
+        <dc:Bounds x="360" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0bh4l32_di" bpmnElement="Gateway_10bz2ml">
+        <dc:Bounds x="645" y="242" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="228" y="223" width="84" height="14" />
+          <dc:Bounds x="625" y="212" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Event_18ybdgd_di" bpmnElement="Event_18ybdgd">
-        <dc:Bounds x="672" y="372" width="36" height="36" />
+      <bpmndi:BPMNShape id="Gateway_0q5xdvv_di" bpmnElement="Gateway_1kmkcqg">
+        <dc:Bounds x="845" y="242" width="50" height="50" />
         <bpmndi:BPMNLabel>
-          <dc:Bounds x="660" y="415" width="60" height="14" />
+          <dc:Bounds x="825" y="212" width="90" height="27" />
         </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_18vw7m5_di" bpmnElement="Activity_1if0inu">
-        <dc:Bounds x="390" y="80" width="100" height="80" />
+      <bpmndi:BPMNShape id="Event_15yltuq_di" bpmnElement="Event_15yltuq">
+        <dc:Bounds x="1112" y="249" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1105" y="292" width="51" height="14" />
+        </bpmndi:BPMNLabel>
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1gsnl93_di" bpmnElement="Activity_16o3zb7">
-        <dc:Bounds x="390" y="350" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_11ix1dc_di" bpmnElement="Activity_11ix1dc">
-        <dc:Bounds x="390" y="220" width="100" height="80" />
+      <bpmndi:BPMNShape id="Activity_16w1hc8_di" bpmnElement="Activity_1bz28eq">
+        <dc:Bounds x="940" y="227" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/content/reference/bpmn20/gateways/bpmn/inclusive_gateway_scenario_4.bpmn
+++ b/content/reference/bpmn20/gateways/bpmn/inclusive_gateway_scenario_4.bpmn
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0y1i2m5" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.6.0">
+  <bpmn:process id="Process_1b9al7j" isExecutable="true">
+    <bpmn:startEvent id="Event_1t1h6tt" name="Start Event">
+      <bpmn:outgoing>Flow_0prs8qy</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:exclusiveGateway id="Gateway_1drlpmm" name="Exclusive Gateway">
+      <bpmn:incoming>Flow_1oca50p</bpmn:incoming>
+      <bpmn:incoming>Flow_10acatm</bpmn:incoming>
+      <bpmn:outgoing>Flow_1oo92xx</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:endEvent id="Event_0r8hu8b" name="End Event">
+      <bpmn:incoming>Flow_08mft0l</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:parallelGateway id="Gateway_0jig9s4" name="Parallel Gateway">
+      <bpmn:incoming>Flow_0prs8qy</bpmn:incoming>
+      <bpmn:outgoing>Flow_1oca50p</bpmn:outgoing>
+      <bpmn:outgoing>Flow_0i1ko9s</bpmn:outgoing>
+    </bpmn:parallelGateway>
+    <bpmn:inclusiveGateway id="Gateway_0pqadc7" name="Inclusive Gateway">
+      <bpmn:incoming>Flow_1oo92xx</bpmn:incoming>
+      <bpmn:outgoing>Flow_0tow7o6</bpmn:outgoing>
+    </bpmn:inclusiveGateway>
+    <bpmn:userTask id="Activity_0k54qey" name="User Task 1">
+      <bpmn:incoming>Flow_0i1ko9s</bpmn:incoming>
+      <bpmn:outgoing>Flow_10acatm</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0prs8qy" sourceRef="Event_1t1h6tt" targetRef="Gateway_0jig9s4" />
+    <bpmn:sequenceFlow id="Flow_1oca50p" sourceRef="Gateway_0jig9s4" targetRef="Gateway_1drlpmm" />
+    <bpmn:sequenceFlow id="Flow_10acatm" sourceRef="Activity_0k54qey" targetRef="Gateway_1drlpmm" />
+    <bpmn:sequenceFlow id="Flow_0i1ko9s" sourceRef="Gateway_0jig9s4" targetRef="Activity_0k54qey" />
+    <bpmn:sequenceFlow id="Flow_0tow7o6" sourceRef="Gateway_0pqadc7" targetRef="Activity_1i5mx7m" />
+    <bpmn:sequenceFlow id="Flow_1oo92xx" sourceRef="Gateway_1drlpmm" targetRef="Gateway_0pqadc7" />
+    <bpmn:sequenceFlow id="Flow_08mft0l" sourceRef="Activity_1i5mx7m" targetRef="Event_0r8hu8b" />
+    <bpmn:userTask id="Activity_1i5mx7m" name="User Task 2">
+      <bpmn:incoming>Flow_0tow7o6</bpmn:incoming>
+      <bpmn:outgoing>Flow_08mft0l</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1b9al7j">
+      <bpmndi:BPMNEdge id="Flow_08mft0l_di" bpmnElement="Flow_08mft0l">
+        <di:waypoint x="950" y="270" />
+        <di:waypoint x="1032" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oo92xx_di" bpmnElement="Flow_1oo92xx">
+        <di:waypoint x="538" y="270" />
+        <di:waypoint x="665" y="270" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="634" y="252" width="19" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0tow7o6_di" bpmnElement="Flow_0tow7o6">
+        <di:waypoint x="715" y="270" />
+        <di:waypoint x="850" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0i1ko9s_di" bpmnElement="Flow_0i1ko9s">
+        <di:waypoint x="273" y="245" />
+        <di:waypoint x="273" y="123" />
+        <di:waypoint x="343" y="123" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_10acatm_di" bpmnElement="Flow_10acatm">
+        <di:waypoint x="443" y="123" />
+        <di:waypoint x="513" y="123" />
+        <di:waypoint x="513" y="245" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1oca50p_di" bpmnElement="Flow_1oca50p">
+        <di:waypoint x="298" y="270" />
+        <di:waypoint x="488" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0prs8qy_di" bpmnElement="Flow_0prs8qy">
+        <di:waypoint x="198" y="270" />
+        <di:waypoint x="248" y="270" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Event_1t1h6tt_di" bpmnElement="Event_1t1h6tt">
+        <dc:Bounds x="162" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="153" y="295" width="55" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_1drlpmm_di" bpmnElement="Gateway_1drlpmm" isMarkerVisible="true">
+        <dc:Bounds x="488" y="245" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="489" y="306" width="47" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0r8hu8b_di" bpmnElement="Event_0r8hu8b">
+        <dc:Bounds x="1032" y="252" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="1025" y="295" width="51" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0jig9s4_di" bpmnElement="Gateway_0jig9s4">
+        <dc:Bounds x="248" y="245" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="231" y="302" width="84" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0k54qey_di" bpmnElement="Activity_0k54qey">
+        <dc:Bounds x="343" y="83" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1y9awzx_di" bpmnElement="Activity_1i5mx7m">
+        <dc:Bounds x="850" y="230" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0pqadc7_di" bpmnElement="Gateway_0pqadc7">
+        <dc:Bounds x="665" y="245" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="645" y="215" width="90" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/content/reference/bpmn20/gateways/inclusive-gateway.md
+++ b/content/reference/bpmn20/gateways/inclusive-gateway.md
@@ -100,13 +100,15 @@ Note that in Camunda's implementation of the inclusive gateway, the following ho
 
 The following examples show under which conditions an inclusive gateway will trigger a join:
 
-1. In the diagram below, the parallel gateway creates three execution tokens. However, only
-   two of the sequence flows join in the inclusive gateway. In this case, the inclusive
-   gateway **will not trigger** a join until the token on `Task 3` is completed and consumed
-   by `End Event 2`. This is not recommended, as the `Inclusive Gateway` join depends on the
-   (unrelated) completion of `Task 3`. In cases like these, it is recommended to use an 
-   [`Exclusive Gateway`]({{< ref "/reference/bpmn20/gateways/exclusive-gateway.md" >}}) 
-   instead of an `Inclusive Gateway`.
+1. In the diagram below, the parallel gateway creates two execution tokens. The first 
+   execution token will wait at `User Task 1`, and the second will reach the
+   `Inclusive Gateway 2` and wait for the gateway to trigger. However, the 
+   `Inclusive Gateway 2` **will not trigger** a join until `User Task 1` is completed and
+   the second token arrives at the gateway. As a result, the `Inclusive Gateway 2` will trigger
+   only once, instead of two times since both tokens will pass the same sequence flow (true). 
+   In cases like these, it is recommended to use an [`Exclusive Gateway`]({{< ref "/reference/bpmn20/gateways/exclusive-gateway.md" >}}) 
+   instead of the `Inclusive Gateway 1`. As a result, only one instance of `User Task 2` will
+   need to be completed.
    <div data-bpmn-diagram="../bpmn/inclusive_gateway_scenario_1"></div>
    
 1. In the following scenario, `Parallel Gateway 1` creates three execution tokens, but
@@ -121,6 +123,12 @@ The following examples show under which conditions an inclusive gateway will tri
    token from `Task 1` into two separate tokens for `Task 3` and `Task 4`.
    <div data-bpmn-diagram="../bpmn/inclusive_gateway_scenario_3"></div>
 
+1. In the last scenario, the parallel gateway creates two execution tokens. The first
+   execution token will wait at `User Task 1`, and the second will reach the
+   `Inclusive Gateway`. The `Inclusive Gateway` will trigger immediately for the first token,
+   and a second time, for the second token, as both tokens arrive on the same sequence flow.
+   As a result, there will be two instances of `User Task 2` that will need to be completed.
+   <div data-bpmn-diagram="../bpmn/inclusive_gateway_scenario_4"></div>
 
 # Camunda Extensions
 


### PR DESCRIPTION
* Provide a correct diagram of the limitation for inclusive gateways. The inclusive gateway will wait for multiple tokens, even though they will all arrive on the same sequence flow.

Related to CAM-13303