### PR TITLE
chore(docs): rename "full" distribution

### DIFF
--- a/content/installation/camunda-bpm-run.md
+++ b/content/installation/camunda-bpm-run.md
@@ -5,11 +5,15 @@ weight: 05
 
 menu:
   main:
-    name: "Camunda Platform Run"
+    name: "Remote Engine Distribution"
     identifier: "installation-camunda-bpm-run"
     parent: "installation-guide"
-    pre: "Install Camunda Platform Run, an easy to configure full distribution of the Camunda Platform. No Java knowledge necessary."
+    pre: "Install Camunda Platform Run, an easy to configure remote engine distribution of the Camunda Platform. No Java knowledge necessary."
 ---
+
+{{< note title="What is a Remote Engine Distribution?" class="info" >}}
+If you need a Remote or Shared Engine Distribution depends on your use-case. Check out the [architecture overview]({{<ref "/introduction/architecture.md" >}}) for more information.
+{{< /note >}}
 
 This page describes the steps to execute Camunda Platform Run.
 

--- a/content/installation/docker.md
+++ b/content/installation/docker.md
@@ -16,7 +16,16 @@ menu:
 
 The Community Edition docker images can be found on [GitHub](https://github.com/camunda/docker-camunda-bpm-platform) and [Docker Hub](https://hub.docker.com/r/camunda/camunda-bpm-platform/).
 
-## Start Camunda Platform using Docker
+## Start Camunda Platform Run using Docker
+
+To start [Camunda Platform Run]({{< ref "/user-guide/camunda-bpm-run.md" >}}) execute the following commands:
+
+```shell
+docker pull camunda/camunda-bpm-platform:run-latest
+docker run -d --name camunda -p 8080:8080 camunda/camunda-bpm-platform:run-latest
+```
+
+## Start Camunda Platform (Tomcat) using Docker
 
 To start the Camunda Platform execute the following commands:
 
@@ -27,14 +36,6 @@ docker run -d --name camunda -p 8080:8080 camunda/camunda-bpm-platform:latest
 
 Please note that by default the Apache Tomcat distribution is used. For a guide on how to use one of the other distributions, see the [tag schema](https://github.com/camunda/docker-camunda-bpm-platform#supported-tagsreleases).
 
-## Start Camunda Platform Run using Docker
-
-To start [Camunda Platform Run]({{< ref "/user-guide/camunda-bpm-run.md" >}}) execute the following commands:
-
-```shell
-docker pull camunda/camunda-bpm-platform:run-latest
-docker run -d --name camunda -p 8080:8080 camunda/camunda-bpm-platform:run-latest
-```
 
 # Enterprise Edition
 

--- a/content/installation/full/_index.md
+++ b/content/installation/full/_index.md
@@ -1,16 +1,20 @@
 ---
 
-title: "Install the Full Distribution"
+title: "Install the Shared Engine Distribution"
 weight: 10
 
 menu:
   main:
-    name: "Full Distribution"
+    name: "Shared Engine Distribution"
     identifier: "installation-guide-full"
     parent: "installation-guide"
-    pre: "Install the Full Distribution (Shared Process Engine and Web Applications) inside an Application Server like Wildfly or Tomcat."
+    pre: "Install the Shared Process Engine and Web Applications inside an Application Server like Wildfly or Tomcat."
 
 ---
+
+{{< note title="What is a Shared Engine Distribution?" class="info" >}}
+If you need a Remote or Shared Engine Distribution depends on your use-case. Check out the [architecture overview]({{<ref "/introduction/architecture.md" >}}) for more information.
+{{< /note >}}
 
 The [Full Distribution][full-distribution] includes a Shared Process engine and (optionally) the Web Applications.
 


### PR DESCRIPTION
* change the order of Docker images to feature Run on top
* Rename "Full Distirution" to "Shared Engine Distribution"
* Rename the "Installation> Camunda Platform Run" to "Remote Engine Distribution"
* link to the architecture page from both pages

related to CAM-12951