### PR TITLE
fix(docs): Prevent line break by shortening name

### DIFF
--- a/content/introduction/extensions.md
+++ b/content/introduction/extensions.md
@@ -41,7 +41,7 @@ The following is an incomplete list of community extensions:
 * [Grails Plugin](https://github.com/plexiti/camunda-grails-plugin)
 * [GraphQL API](https://github.com/camunda/camunda-graphql)
 * [Keycloak Identity Provider Plugin](https://github.com/camunda/camunda-bpm-identity-keycloak)
-* [Micronaut Camunda Integration](https://github.com/NovatecConsulting/micronaut-camunda-bpm)
+* [Micronaut Integration](https://github.com/NovatecConsulting/micronaut-camunda-bpm)
 * [Migration API](https://github.com/camunda/camunda-bpm-migration)
 * [Mockito Testing Library](https://github.com/camunda/camunda-bpm-mockito)
 * [Needle Testing Library](https://github.com/camunda/camunda-bpm-needle)

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -172,7 +172,7 @@
             <a href="https://github.com/camunda/camunda-graphql">GraphQL API</a>
           </div>
           <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/NovatecConsulting/micronaut-camunda-bpm">Micronaut Camunda Integration</a>
+            <a href="https://github.com/NovatecConsulting/micronaut-camunda-bpm">Micronaut Integration</a>
           </div>
           <div class="col-xs-6 col-md-4">
             <a href="https://github.com/camunda/camunda-bpm-migration">Migration API</a>


### PR DESCRIPTION
This fixes a glitch in the documentation, i.e. the long name "Micronaut Camunda Integration" previously forced a line break which does not look nice:

![image](https://user-images.githubusercontent.com/5685151/114974314-6efddc80-9e82-11eb-8030-d1b52997c3de.png)

I fixed it by shorting the name. Note: I'm the author of the Micronaut Integration so I'm fine with the change :-)

Please also merge this to the 7.15 docs.
