### PR TITLE
CAM-11523: chore(rest): fix typos in authorization rest docs

### DIFF
--- a/content/reference/rest/authorization/get-query-count.md
+++ b/content/reference/rest/authorization/get-query-count.md
@@ -40,11 +40,11 @@ GET `/authorization/count`
   </tr>
   <tr>
     <td>userIdIn</td>
-    <td>Filter by a comma-seperated list of userIds.</td>
+    <td>Filter by a comma-separated list of userIds.</td>
   </tr>
   <tr>
     <td>groupIdIn</td>
-    <td>Filter by a comma-seperated list of groupIds.</td>
+    <td>Filter by a comma-separated list of groupIds.</td>
   </tr>
   <tr>
     <td>resourceType</td>

--- a/content/reference/rest/authorization/get.md
+++ b/content/reference/rest/authorization/get.md
@@ -82,11 +82,6 @@ A JSON array with the following properties:
     <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
   <tr>
-    <td>links</td>
-    <td>Object</td>
-    <td>A JSON array containing links to interact with the resource. The links contain only operations that the currently authenticated user would be authorized to perform.</td>
-  </tr>
-  <tr>
     <td>removalTime</td>
     <td>String</td>
     <td>

--- a/content/reference/rest/authorization/post-create.md
+++ b/content/reference/rest/authorization/post-create.md
@@ -111,11 +111,6 @@ A JSON array with the following properties:
     <td>The resource Id. The value "*" represents an authorization ranging over all instances of a resource.</td>
   </tr>
   <tr>
-    <td>links</td>
-    <td>Object</td>
-    <td>A JSON array containing links to interact with the resource. The links contain only operations that the currently authenticated user would be authorized to perform.</td>
-  </tr>
-  <tr>
     <td>removalTime</td>
     <td>String</td>
     <td>


### PR DESCRIPTION
* Fix typos and remove missing properties in the Authorization Rest API docs.
* Updated a typo in the `GET /authorization/count` docs (seperated -> separated);
* In `GET /authorization` and `POST /authorization/create`, it is stated that the `AuthorizationDto` class contains a links property. This is not true, so I removed it.

Related to CAM-11523