### PR TITLE
CAM-11560: chore(rest): fix typos and missing properties

### DIFF
--- a/content/reference/rest/history/detail/get-detail-query-count.md
+++ b/content/reference/rest/history/detail/get-detail-query-count.md
@@ -87,6 +87,11 @@ GET `/history/detail/count`
     <td>Excludes all task-related <strong>HistoricDetails</strong>, so only items which have no task id set will be selected. When this parameter is used together with <code>taskId</code>, this call is ignored and task details are <strong>not</strong> excluded. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
   </tr>
   <tr>
+    <td>initial</td>
+    <td>boolean</td>
+    <td>Restrict to historic variable updates that contain only initial variable values. Value may only be <code>true</code>, as <code>false</code> is the default behavior.</td>
+  </tr>
+  <tr>
     <td>occurredBefore</td>
     <td>Restrict to historic details that occured before the given date (including the date). By default*, the date must have the format <code>yyyy-MM-dd'T'HH:mm:ss.SSSZ</code>, e.g., <code>2013-01-23T14:42:45.000+0200</code>.</td>
   </tr>

--- a/content/reference/rest/history/detail/get-detail-query-count.md
+++ b/content/reference/rest/history/detail/get-detail-query-count.md
@@ -43,6 +43,10 @@ GET `/history/detail/count`
     <td>Filter by execution id.</td>
   </tr>
   <tr>
+    <td>taskId</td>
+    <td>Filter by task id.</td>
+  </tr>
+  <tr>
     <td>activityInstanceId</td>
     <td>Filter by activity instance id.</td>
   </tr>

--- a/content/reference/rest/history/detail/get-detail-query.md
+++ b/content/reference/rest/history/detail/get-detail-query.md
@@ -44,6 +44,10 @@ GET `/history/detail`
     <td>Filter by execution id.</td>
   </tr>
   <tr>
+    <td>taskId</td>
+    <td>Filter by task id.</td>
+  </tr>
+  <tr>
     <td>activityInstanceId</td>
     <td>Filter by activity instance id.</td>
   </tr>

--- a/content/reference/rest/history/detail/get-detail.md
+++ b/content/reference/rest/history/detail/get-detail.md
@@ -89,7 +89,7 @@ An object having the following properties:
   <tr>
     <td>activityInstanceId</td>
     <td>String</td>
-    <td>The id of the execution the historic detail belongs to.</td>
+    <td>The id of the activity instance the historic detail belongs to.</td>
   </tr>
   <tr>
     <td>executionId</td>

--- a/content/reference/rest/history/detail/post-detail-query.md
+++ b/content/reference/rest/history/detail/post-detail-query.md
@@ -67,6 +67,10 @@ A JSON object with the following properties:
     <td>Filter by execution id.</td>
   </tr>
   <tr>
+    <td>taskId</td>
+    <td>Filter by task id.</td>
+  </tr>
+  <tr>
     <td>activityInstanceId</td>
     <td>Filter by activity instance id.</td>
   </tr>


### PR DESCRIPTION
* Fix typos and add missing properties in the Historic Details Rest API endpoins docs.

Related to CAM-11560