### PR TITLE
CAM-11564: chore(rest): clarify cleanup endpoint limitation

### DIFF
--- a/content/reference/rest/history/history-cleanup/get-cleanup-configuration.md
+++ b/content/reference/rest/history/history-cleanup/get-cleanup-configuration.md
@@ -43,12 +43,18 @@ A JSON object representing batch window datetimes with timezone.
   <tr>
     <td>batchWindowStartTime</td>
     <td>Date</td>
-    <td>Start time of the current or next batch window</td>
+    <td>Start time of the current or next batch window. By <a href="{{<ref "/reference/rest/overview/date-format.md" >}}">default</a>,
+        the date must have the format <code>yyyy-MM-dd'T'HH:mm:ss.SSSZ</code>, e.g., 
+        <code>2013-01-23T14:42:45.000+0200</code>.
+    </td>
   </tr>
   <tr>
     <td>batchWindowEndTime</td>
     <td>Date</td>
-    <td>End time of the current or next batch window</td>
+    <td>End time of the current or next batch window. By <a href="{{<ref "/reference/rest/overview/date-format.md" >}}">default</a>,
+        the date must have the format <code>yyyy-MM-dd'T'HH:mm:ss.SSSZ</code>, e.g., 
+        <code>2013-01-23T14:42:45.000+0200</code>.
+    </td>
   </tr>
   <tr>
     <td>enabled</td>

--- a/content/reference/rest/history/history-cleanup/get-history-cleanup-job.md
+++ b/content/reference/rest/history/history-cleanup/get-history-cleanup-job.md
@@ -13,7 +13,7 @@ menu:
 ---
 <b>Deprecated!</b> Use `GET /history/cleanup/jobs` instead.
 
-Finds history cleanup job (See [History cleanup]({{< ref "/user-guide/process-engine/history.md#job-progress">}})).
+Finds history cleanup job (See [History cleanup]({{< ref "/user-guide/process-engine/history.md#history-cleanup">}})).
 
 # Method
 

--- a/content/reference/rest/history/history-cleanup/get-history-cleanup-jobs.md
+++ b/content/reference/rest/history/history-cleanup/get-history-cleanup-jobs.md
@@ -11,7 +11,7 @@ menu:
     pre: "GET `/history/cleanup/jobs`"
 
 ---
-Finds history cleanup jobs (See [History cleanup]({{< ref "/user-guide/process-engine/history.md#job-progress">}})).
+Finds history cleanup jobs (See [History cleanup]({{< ref "/user-guide/process-engine/history.md#history-cleanup">}})).
 
 # Method
 

--- a/content/reference/rest/history/history-cleanup/post-history-cleanup.md
+++ b/content/reference/rest/history/history-cleanup/post-history-cleanup.md
@@ -43,7 +43,10 @@ Not used
 # Result
 
 {{< note title="Result is not reliable any more" class="warning" >}}
-  Be aware, that since v. 7.9.0, the correct response object is not guaranteed any more. Use `GET /history/cleanup/jobs` to find history cleanup jobs. 
+  This endpoint will return at most a single history cleanup job. Since version `7.9.0` it is possible 
+  to configure multiple [parallel history cleanup jobs]({{<ref "/user-guide/process-engine/history.md#parallel-execution" >}})
+  Use [`GET /history/cleanup/jobs`]({{<ref "/reference/rest/history/history-cleanup/get-history-cleanup-jobs.md" >}}) 
+  to find all the available history cleanup jobs.
 {{</note>}}
 
 A JSON object representing scheduled job.


### PR DESCRIPTION
* Make it clearer why the response of the `POST /history/cleanup` endpoint is unreliable from version 7.9.0.

Related to CAM-11564