### PR TITLE
CAM-13375: docs(content): Update Community Hub Information

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -144,7 +144,7 @@
           <p>A number of <a href="{{ ref . "/introduction/extensions.md" }}">Community Extensions</a> enhance Camunda
             with additional capabilities. 
         </header>
-        Browse the <a href="https://github.com/camunda-community-hub">Camunda Community Hub</a> for information on [building a Camunda Community Extension](https://github.com/camunda-community-hub/community#creating-a-new-camunda-community-extension), 
+        Browse the <a href="https://github.com/camunda-community-hub">Camunda Community Hub</a> for information on <a href="https://github.com/camunda-community-hub/community#creating-a-new-camunda-community-extension">building a Camunda Community Extension</a>, 
         discover new Camunda Community Extension open source projects to contribute to, and more.</p>
         </div>
       </section>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -142,72 +142,10 @@
           <h2>Community Extensions</h2>
 
           <p>A number of <a href="{{ ref . "/introduction/extensions.md" }}">Community Extensions</a> enhance Camunda
-            with additional capabilities. You can also browse the <a href="https://github.com/camunda-community-hub">Camunda Community Hub</a> for information on building a Camunda Community Extension, discover new Camunda Community Extension open source projects to contribute to, and more.</p>
+            with additional capabilities. 
         </header>
-
-        <!-- list below is sorted in alphabetical order -->
-        <!-- keep consistent on all branches 7.4+ -->
-        <!-- keep consistent with list in extensions.md -->
-
-        <div class="row">
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-bpm-camel">Apache Camel Integration</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/docker-camunda-bpm-platform">Camunda Docker Images</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/dmn-scala">DMN Scala Extension</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-bpm-elasticsearch">Elastic Search Extension</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-bpm-mail">Email Connectors</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/plexiti/camunda-grails-plugin">Grails Plugin</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-graphql">GraphQL API</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/NovatecConsulting/micronaut-camunda-bpm">Micronaut Integration</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-bpm-migration">Migration API</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-bpm-mockito">Mockito Testing Library</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-bpm-needle">Needle Testing Library</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-bpm-platform-osgi">OSGi Integration</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="http://camunda.github.io/camunda-bpm-php-sdk/">PHP SDK</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-process-test-coverage">Process Test Coverage</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-bpm-reactor">Reactor Event Bus</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-bpm-assert-scenario/">Scenario Testing Library</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-sso-jboss">Single Sign On for JBoss</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-tasklist-translations">Tasklist Translations</a>
-          </div>
-          <div class="col-xs-6 col-md-4">
-            <a href="https://github.com/camunda/camunda-bpm-wildfly-swarm">Wildfly Swarm</a>
-          </div>
-
+        Browse the <a href="https://github.com/camunda-community-hub">Camunda Community Hub</a> for information on [building a Camunda Community Extension](https://github.com/camunda-community-hub/community#creating-a-new-camunda-community-extension), 
+        discover new Camunda Community Extension open source projects to contribute to, and more.</p>
         </div>
       </section>
     </div>


### PR DESCRIPTION
Added links to how to build a community extension and removed list of extensions in favor of pointing directly to the Community Hub.