### PR TITLE
(chore) docs: Update Capitalization of REST API

### DIFF
--- a/content/reference/rest/_index.md
+++ b/content/reference/rest/_index.md
@@ -1,11 +1,11 @@
 ---
 
-title: "Rest Api Reference"
+title: "REST API Reference"
 weight: 10
 
 menu:
   main:
-    name: "Rest Api"
+    name: "REST API"
     identifier: "rest-api"
     parent: "references"
 


### PR DESCRIPTION
Updated capitalization of the words 'REST API'