### PR TITLE
adjust javadoc links in scripting page

### DIFF
--- a/content/user-guide/process-engine/scripting.md
+++ b/content/user-guide/process-engine/scripting.md
@@ -363,7 +363,7 @@ task = execution.getProcessEngineServices().getTaskService()
 
 Camunda's Java API provides access to Camunda's process engine services; these services can be accessed using Scripts:
 
-{{< javadocref page="?org/camunda/bpm/engine/ProcessEngineServices.html" text="Process Engine Services" >}}
+{{< javadocref page="?org/camunda/bpm/engine/ProcessEngineServices.html" text="Process Engine Services" >}} \
 
 {{< javadocref page="?org/camunda/bpm/engine/package-summary.html" text="Public Java API of Camunda Platform Engine" >}}
 

--- a/content/user-guide/process-engine/scripting.md
+++ b/content/user-guide/process-engine/scripting.md
@@ -338,7 +338,7 @@ i.e., `$sum`)
 
 There are also special variables:
 
-1. `execution`, which is always available if the script is executed in an execution scope (e.g., in a script task) ({< javadocref page="?org/camunda/bpm/engine/delegate/DelegateExecution.html" text="DelegateExecution" >}}).
+1. `execution`, which is always available if the script is executed in an execution scope (e.g., in a script task) ({{< javadocref page="?org/camunda/bpm/engine/delegate/DelegateExecution.html" text="DelegateExecution" >}}).
 1. `task`, which is available if the script is executed in a task scope (e.g., a task listener) ({{< javadocref page="?org/camunda/bpm/engine/delegate/DelegateTask.html" text="DelegateTask" >}}).
 1. `connector`, which is available if the script is executed in a connector variable scope (e.g., outputParameter of a camunda:connector) ({{< javadocref page="?org/camunda/connect/plugin/impl/ConnectorVariableScope.html" text="ConnectorVariableScope" >}}).
 

--- a/content/user-guide/process-engine/scripting.md
+++ b/content/user-guide/process-engine/scripting.md
@@ -338,9 +338,9 @@ i.e., `$sum`)
 
 There are also special variables:
 
-1. `execution`, which is always available if the script is executed in an execution scope (e.g., in a script task) ([`DelegateExecution`](https://docs.camunda.org/javadoc/camunda-bpm-platform/7.7/org/camunda/bpm/engine/delegate/DelegateExecution.html)).
-1. `task`, which is available if the script is executed in a task scope (e.g., a task listener) ([`DelegateTask`](https://docs.camunda.org/javadoc/camunda-bpm-platform/7.7/org/camunda/bpm/engine/delegate/DelegateTask.html)).
-1. `connector`, which is available if the script is executed in a connector variable scope (e.g., outputParameter of a camunda:connector) ([`ConnectorVariableScope`](https://docs.camunda.org/javadoc/camunda-bpm-platform/7.7/org/camunda/connect/plugin/impl/ConnectorVariableScope.html)).
+1. `execution`, which is always available if the script is executed in an execution scope (e.g., in a script task) ({< javadocref page="?org/camunda/bpm/engine/delegate/DelegateExecution.html" text="DelegateExecution" >}}).
+1. `task`, which is available if the script is executed in a task scope (e.g., a task listener) ({{< javadocref page="?org/camunda/bpm/engine/delegate/DelegateTask.html" text="DelegateTask" >}}).
+1. `connector`, which is available if the script is executed in a connector variable scope (e.g., outputParameter of a camunda:connector) ({{< javadocref page="?org/camunda/connect/plugin/impl/ConnectorVariableScope.html" text="ConnectorVariableScope" >}}).
 
 These variables correspond to the `DelegateExecution`, `DelegateTask` or resp. `ConnectorVariableScope`
 interface which means that it can be used to get and set variables or access process engine services.
@@ -363,8 +363,9 @@ task = execution.getProcessEngineServices().getTaskService()
 
 Camunda's Java API provides access to Camunda's process engine services; these services can be accessed using Scripts:
 
-[Process Engine Services](https://docs.camunda.org/javadoc/camunda-bpm-platform/7.3/org/camunda/bpm/engine/ProcessEngineServices.html)
-[Public Java API of Camunda Platform Engine](https://docs.camunda.org/javadoc/camunda-bpm-platform/7.7/org/camunda/bpm/engine/package-summary.html)
+{{< javadocref page="?org/camunda/bpm/engine/ProcessEngineServices.html" text="Process Engine Services" >}}
+
+{{< javadocref page="?org/camunda/bpm/engine/package-summary.html" text="Public Java API of Camunda Platform Engine" >}}
 
 Example of creating a BPMN Message that correlates with the message key "work":
 


### PR DESCRIPTION
Replace fixed url with the javadocref function