### PR TITLE
chore(standalone-webapp): replace dbcp by Hikari

### DIFF
--- a/content/installation/standalone-webapplication.md
+++ b/content/installation/standalone-webapplication.md
@@ -85,7 +85,7 @@ web application by using the following url:
 # Database Configuration
 
 The Camunda standalone webapp is initially configured using a file-based `H2` database
-and an Apache Commons DBCP datasource. The `h2` database is only useful for demo purposes.
+and a HikariCP datasource. The `h2` database is only useful for demo purposes.
 If you want to use the standalone webapp in production we recommend using a different database.
 
 In order to configure another database, edit the file named `WEB-INF/applicationContext.xml` inside the
@@ -94,9 +94,9 @@ In order to configure another database, edit the file named `WEB-INF/application
 ```xml
 <bean id="dataSource" class="org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy">
   <property name="targetDataSource">
-    <bean class="org.apache.commons.dbcp.BasicDataSource">
+    <bean class="com.zaxxer.hikari.HikariDataSource">
       <property name="driverClassName" value="org.h2.Driver" />
-      <property name="url" value="jdbc:h2:./camunda-h2-dbs/process-engine;MVCC=TRUE;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE" />
+      <property name="jdbcUrl" value="jdbc:h2:./camunda-h2-dbs/process-engine;MVCC=TRUE;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE" />
       <property name="username" value="sa" />
       <property name="password" value="" />
     </bean>

--- a/content/update/minor/715-to-716/_index.md
+++ b/content/update/minor/715-to-716/_index.md
@@ -76,15 +76,15 @@ There are no new mandatory dependencies for process applications.
 
 # Standalone Web Application
 
-If the standalone web application is in use, the current `war` artifact must be replaced by its new version.
+If you use a standalone web application, replace the current `war` artifact by its new version. 
+Take the following steps to complete the update:
 
-If a database other than the default H2 database is used, the following steps must be taken:
-
-1. Undeploy the current version of the standalone web application
-2. Update the database to the new schema as described in the [database update](#database-updates) section
-3. Reconfigure the database as described in the [installation]({{< ref "/installation/standalone-webapplication.md#database-configuration" >}})
-   section
-4. Deploy the new and configured standalone web application to the server
+1. Undeploy the current version of the standalone web application.
+2. Update the database to the new schema as described in the [database update](#database-updates) section.
+3. Configure the database as described in the [installation]({{< ref "/installation/standalone-webapplication.md#database-configuration" >}})
+   section. **Note** that with 7.16 the standalone web applications use **HikariCP** for data sources instead of Apache Commons DBCP. Replace the
+   `targetDataSource`'s bean class to `com.zaxxer.hikari.HikariDataSource` and rename the `url` parameter of the data source to `jdbcUrl`.
+4. Deploy the new and configured standalone web application to the server.
 
 # Set Variables on Process Instance Migration
 

--- a/content/update/patch-level.md
+++ b/content/update/patch-level.md
@@ -685,6 +685,27 @@ With this release, the following dependencies of Spin have been updated:
 * accessors-smart from 1.2 to 2.4.7
 * json-smart from 2.3 to 2.4.7
 
+### Standalone Webapplication: HikariCP replaces Commons DBCP
+
+The standalone web applications now use HikariCP for data source configuration instead of Apache Commons DBCP. Replace
+the `org.apache.commons.dbcp.BasicDataSource` class in your `applicationContext.xml` with a
+`com.zaxxer.hikari.HikariDataSource`. The HikariCP data source expects the JDBC URL on a property called `jdbcUrl` 
+instead of `url`. Thus, you need to rename the `url` property. Your data source description should look similar to 
+this, with `DB-DRIVER-CLASS`, `JDBC-URL`, `DB-USER`, and `DB-PASSWORD` replaced by values related to your database:
+
+```xml
+<bean id="dataSource" class="org.springframework.jdbc.datasource.TransactionAwareDataSourceProxy">
+  <property name="targetDataSource">
+    <bean class="com.zaxxer.hikari.HikariDataSource">
+      <property name="driverClassName" value="DB-DRIVER-CLASS" />
+      <property name="jdbcUrl" value="JDBC-URL" />
+      <property name="username" value="DB-USER" />
+      <property name="password" value="DB-PASSWORD" />
+    </bean>
+  </property>
+</bean>
+```
+
 # Full Distribution
 
 This section is applicable if you installed the [Full Distribution]({{< ref "/introduction/downloading-camunda.md#full-distribution" >}}) with a **shared process engine**. In this case you need to update the libraries and applications installed inside the application server.


### PR DESCRIPTION
* adjusts standalone webapp database configuration paragraph to reflect
   current implementation

related to CAM-13519