### PR TITLE
Update link to example in json-data.md

### DIFF
--- a/content/reference/forms/embedded-forms/json-data.md
+++ b/content/reference/forms/embedded-forms/json-data.md
@@ -62,4 +62,4 @@ You can use JSON objects in your embedded forms. In order to persist this data i
 
 # Full Example
 
-A full example of this feature can be found in the [Camunda Platform Examples Repository](https://github.com/camunda/camunda-bpm-examples/tree/master/usertask/task-form-embedded-json).
+A full example of this feature can be found in the [Camunda Platform Examples Repository](https://github.com/camunda/camunda-bpm-examples/tree/master/usertask/task-form-embedded-json-variables).


### PR DESCRIPTION
The link in the `Full Example` section of `https://docs.camunda.org/manual/latest/reference/forms/embedded-forms/json-data/` is currently a 404.

![image](https://user-images.githubusercontent.com/1652117/125036284-1dd14380-e093-11eb-995b-06c462278281.png)

The current link points to [https://github.com/camunda/camunda-bpm-examples/tree/master/usertask/task-form-embedded-json](https://github.com/camunda/camunda-bpm-examples/tree/master/usertask/task-form-embedded-json).
The page seems to have moved to [https://github.com/camunda/camunda-bpm-examples/tree/master/usertask/task-form-embedded-json-variables](https://github.com/camunda/camunda-bpm-examples/tree/master/usertask/task-form-embedded-json-variables)

This PR updates the link