### PR TITLE
How to reference deployed files

### DIFF
--- a/content/user-guide/camunda-bpm-run.md
+++ b/content/user-guide/camunda-bpm-run.md
@@ -91,7 +91,7 @@ Camunda Platform Run is pre-configured to use a file-based H2 database for testi
 
 In the unpacked distro, you will find a `resources` folder. All files (including BPMN, DMN, CMMN, form, and script files) will be deployed when you start Camunda Platform Run.
 
-You can reference forms and scripts in the BPMN diagram with `embedded:deployment:/my-form.html`, `camunda-forms:deployment:/myform.form` or `deployment:/my-script.js`. (The deployment adds an extra `/` as prefix to the filename.) 
+You can reference forms and scripts in the BPMN diagram with `embedded:deployment:/my-form.html`, `camunda-forms:deployment:/myform.form`, or `deployment:/my-script.js`. The deployment requires adding an extra `/` as a prefix to the filename.
 
 Deployments via the [REST API]({{< ref "/reference/rest/deployment/post-deployment.md" >}}) are still possible.
 

--- a/content/user-guide/camunda-bpm-run.md
+++ b/content/user-guide/camunda-bpm-run.md
@@ -91,6 +91,8 @@ Camunda Platform Run is pre-configured to use a file-based H2 database for testi
 
 In the unpacked distro, you will find a `resources` folder. All files (including BPMN, DMN, CMMN, form, and script files) will be deployed when you start Camunda Platform Run.
 
+You can reference forms and scripts in the BPMN diagram with `embedded:deployment:/my-form.html`, `camunda-forms:deployment:/myform.form` or `deployment:/my-script.js`. (The deployment adds an extra `/` as prefix to the filename.) 
+
 Deployments via the [REST API]({{< ref "/reference/rest/deployment/post-deployment.md" >}}) are still possible.
 
 


### PR DESCRIPTION
Add a hint how to reference deployed files in the BPMN diagram. It is not obvious from the Cockpit as the leading `/` is not mentioned in the deployment.