### PR TITLE
Rename goovy to groovy

### DIFF
--- a/content/user-guide/process-engine/scripting.md
+++ b/content/user-guide/process-engine/scripting.md
@@ -491,7 +491,7 @@ During the execution of scripts, it might be desired to print to the console due
 
 Here are examples on how this can be accomplished in the respective language:
 
-* Goovy:
+* Groovy:
 
 ```groovy
 println 'This prints to the console'


### PR DESCRIPTION
In [Scripting | docs.camunda.org](https://docs.camunda.org/manual/7.15/user-guide/process-engine/scripting/#printing-to-console-using-scripts) instead of `groovy` it says `goovy`.