### PR TITLE
chore(installation): add GraalJS to manual install guides

### DIFF
--- a/content/installation/full/jboss/manual.md
+++ b/content/installation/full/jboss/manual.md
@@ -411,3 +411,14 @@ Add the following modules (if not existing) from the folder `$JBOSS_DISTRIBUTION
 * `org/freemarker/freemarker`
 * `org/camunda/commons/camunda-commons-logging`
 * `org/camunda/commons/camunda-commons-utils`
+
+## GraalVM JavaScript Integration
+
+Add the following modules (if not existing) from the folder `$JBOSS_DISTRIBUTION/modules/` to the folder `$JBOSS_HOME/modules/`:
+
+* `org/graalvm/js/js`
+* `org/graalvm/js/js-scriptengine`
+* `org/graalvm/regex/regex`
+* `org/graalvm/sdk/graal-sdk`
+* `org/graalvm/truffle/truffle-api`
+* `com/ibm/icu/icu4j`

--- a/content/installation/full/tomcat/manual.md
+++ b/content/installation/full/tomcat/manual.md
@@ -253,3 +253,14 @@ Add the following artifacts (if not existing) from the folder `$TOMCAT_DISTRIBUT
 * `camunda-template-engines-freemarker-$TEMPLATE_VERSION.jar`
 * `freemarker-2.3.29.jar`
 * `camunda-commons-utils-$COMMONS_VERSION.jar`
+
+## GraalVM JavaScript Integration
+
+Add the following artifacts (if not existing) from the folder `$TOMCAT_DISTRIBUTION/lib/` to the folder `$TOMCAT_HOME/lib/`:
+
+* `graal-sdk-21.1.0.jar`
+* `icu4j-68.2.jar`
+* `js-21.1.0.jar`
+* `js-scriptengine-21.1.0.jar`
+* `regex-21.1.0.jar`
+* `truffle-api-21.1.0.jar`

--- a/content/installation/full/was/manual.md
+++ b/content/installation/full/was/manual.md
@@ -375,6 +375,16 @@ Add the following artifacts (if not existing) from the folder `$WAS_DISTRIBUTION
 * `freemarker-2.3.29.jar`
 * `camunda-commons-utils-$COMMONS_VERSION.jar`
 
+## GraalVM JavaScript Integration
+
+Add the following artifacts (if not existing) from the folder `$WAS_DISTRIBUTION/modules/lib/` to the `Camunda` shared library folder:
+
+* `graal-sdk-21.1.0.jar`
+* `icu4j-68.2.jar`
+* `js-21.1.0.jar`
+* `js-scriptengine-21.1.0.jar`
+* `regex-21.1.0.jar`
+* `truffle-api-21.1.0.jar`
 
 # Process Applications
 


### PR DESCRIPTION
* adds a description on GraalVM JavaScript integration in the manual server
  installation guides for Tomcat, JBoss/WildFly/WebSphere

related to CAM-13780