### PR TITLE
CAM-13835: doc(quarkus): add quarkus extension config docs

### DIFF
--- a/content/user-guide/process-engine/database/cockroachdb-configuration.md
+++ b/content/user-guide/process-engine/database/cockroachdb-configuration.md
@@ -154,7 +154,7 @@ When the process engine is used inside a Spring/Java EE application but left to 
 transactions, the recommendations from the sections above remain valid.
 {{< /note >}}
 
-The [Spring]({{< ref "/user-guide/spring-framework-integration/transactions.md" >}})/[Java EE]({{< ref "/user-guide/cdi-java-ee-integration/jta-transaction-integration.md" >}}) 
+The [Spring]({{< ref "/user-guide/spring-framework-integration/transactions.md" >}})/[Java EE]({{< ref "/user-guide/cdi-java-ee-integration/jta-transaction-integration.md" >}})/[Quarkus]({{< ref "/user-guide/quarkus-integration/configuration.md#datasource" >}}) 
 Transaction integrations enable developers to manage transactions through the respective framework. 
 This means that the process engine doesn't control when transactions are started, committed, 
 or rolled back. 

--- a/content/user-guide/quarkus-integration/configuration.md
+++ b/content/user-guide/quarkus-integration/configuration.md
@@ -23,10 +23,17 @@ Camunda Process Engine Configuration properties.
 An instance of the `QuarkusProcessEngineConfiguration` class configures the process engine in a Quarkus application. 
 A `QuarkusProcessEngineConfiguration` instance provides the following defaults:
 
-* Transactions are externally managed by default.
-* Database schema update is set to `true`. The [Database Configuration][db-schema-update] section documents goes into 
-  more details.
-* No JDBC configuration is present. A Quarkus datasource should be configured and used.
+* The job executor is activated by default, i.e. the `jobExecutorActivate` property is set to `true`.
+* Transactions are externally managed by default since the `transactionsExternallyManaged` is set to `true`.
+* The `databaseSchemaUpdate` property is set to `true`. The [Database Configuration][db-schema-update] section goes into 
+  more details on this propery and the resulting behavior.
+* No JDBC configuration is present since a Quarkus datasource should be configured and used. As a result, the following
+  properties are set to `null`:
+  * `jdbcUrl`
+  * `jdbcUsername`
+  * `jdbcPassword`
+  * `jdbcDriver`
+* The `idGenerator` is set to an instance of {{< javadocref page="?org/camunda/bpm/engine/impl/persistence/StrongUuidGenerator.html" text="StrongUuidGenerator" >}}.
 
 Quarkus allows to configure a Quarkus application via a [MicroProfile Config][mp-config] source. You can read more about 
 configuring a Quarkus application in the [Quarkus configuration][quarkus-config] page. The Camunda Quarkus extension 

--- a/content/user-guide/quarkus-integration/configuration.md
+++ b/content/user-guide/quarkus-integration/configuration.md
@@ -11,19 +11,178 @@ menu:
 
 ---
 
+This section of the Camunda Quarkus extension documentation covers the configuration options for the process engine
+within a Quarkus application.
+
+The documentation on the Camunda Quarkus Extension Configuration is intended for Quarkus application developers. It 
+requires some knowledge on [Quarkus CDI support][quarkus-cdi], [Quarkus configuration][quarkus-config], as well as
+Camunda Process Engine Configuration properties.
+
 ## Process Engine Configuration
 
-Give example how to configure the engine programmatically.
+An instance of the `QuarkusProcessEngineConfiguration` class configures the process engine in a Quarkus application. 
+A `QuarkusProcessEngineConfiguration` instance provides the following defaults:
 
-### Job Executor
+* Transactions are externally managed by default.
+* Database schema update is set to `true`. The [Database Configuration][db-schema-update] section documents goes into 
+  more details.
+* No JDBC configuration is present. A Quarkus datasource should be configured and used.
+
+Quarkus allows to configure a Quarkus application via a [MicroProfile Config][mp-config] source. You can read more about 
+configuring a Quarkus application in the [Quarkus configuration][quarkus-config] page. The Camunda Quarkus extension 
+docs use the `application.properties` format in the examples, but you can use any supported Quarkus config source.
+
+You can set any process engine configuration properties under the `quarkus.camunda` prefix. The 
+[Process Engine Configuration Properties][engine-properties] page documents all the available properties. Please 
+convert any property names from `camelCase` to the `kebab-case` format, like in the following example:
+
+```properties
+quarkus.camunda.cmmn-enabled=false
+quarkus.camunda.dmn-enabled=false
+quarkus.camunda.history=none
+quarkus.camunda.initialize-telemetry=false
+```
+
+### Programmatic Process Engine Configuration
+
+You can also configure the process engine programmatically, by providing a `QuarkusProcessEngineConfiguration` CDI bean.
+
+```java
+  @ApplicationScoped
+  static class MyConfig {
+
+    @Produces
+    public QuarkusProcessEngineConfiguration customEngineConfig() {
+
+      QuarkusProcessEngineConfiguration engineConfig = new QuarkusProcessEngineConfiguration();
+      
+      // your custom configuration is done here
+      engineConfig.setProcessEngineName("customEngine");
+
+      return engineConfig;
+    }
+
+  }
+```
+
+Note that values of properties set in a `QuarkusProcessEngineConfiguration` instance have a lower ordinal than
+properties defined in a Quarkus config source. 
+
+In the above example, a `QuarkusProcessEngineConfiguration` CDI bean defines "customEngine" as the `processEngineName`. 
+However, if you define the following in an `application.properties` file
+
+```properties
+quarkus.camunda.process-engine-name=quarkusEngine
+```
+
+then "quarkusEngine" will be used as the process engine name since Quarkus config sources have a higher ordinal than a 
+`QuarkusProcessEngineConfiguration` CDI bean.
+
+## Job Executor Configuration
+
+As with the process engine configuration properties [above](#process-engine-configuration), you can set any job executor 
+configuration properties under the `quarkus.camunda.job-executor` prefix. The [Job Executor Configuration Properties][executor-properties] 
+page documents all the available properties. Convert any property names you intend to use from `camelCase` to the 
+`kebab-case` format, like in the following example:
+
+```properties
+quarkus.camunda.job-executor.max-jobs-per-acquisition=5
+quarkus.camunda.job-executor.lock-time-in-millis=500000
+quarkus.camunda.job-executor.wait-time-in-millis=7000
+quarkus.camunda.job-executor.max-wait=65000
+```
 
 ## Quarkus Extension Configuration
 
-* datasource
-* job executor thread pool
+In addition to the general process engine, and job executor, configuration properties mentioned in the previous 
+sections, the Camunda Quarkus extension provides some Quarkus-specific configuration properties. They can be set
+through a Quarkus config source, but not through the `QuarkusProcessEngineConfiguration` class. You can find all
+the Quarkus-specific properties in the following table:
 
-One example with all properties mixed in the end.
+<table class="table desc-table">
+  <tr>
+    <th>Prefix</th>
+    <th>Property name</th>
+    <th>Description</th>
+    <th>Default value</th>
+  </tr>
+
+  <tr><td colspan="4"><b>Data Source</b></td></tr>
+  
+  <tr>
+    <td rowspan="1"><code>quarkus.camunda</code></td>
+    <td><code>.datasource</code></td>
+    <td>
+      Specifies which Quarkus datasource to use. If not defined, the primary Quarkus datasource will be used. 
+      For configuring a Quarkus Datasource, have a look on the [Quarkus Datasource][quarkus-datasource] page.
+    </td>
+    <td><code>&#60;default&#62;</code></td>
+  </tr>
+
+  <tr><td colspan="4"><b>Job Executor</b></td></tr>
+
+  <tr>
+    <td rowspan="2"><code>quarkus.camunda.job-executor.thread-pool</code></td>
+    <td><code>.max-pool-size</code></td>
+    <td>Sets the maximum number of threads that can be present in the thread pool.</td>
+    <td><code>10</code></td>
+  </tr>
+
+  <tr>
+    <td><code>.queue-size</code></td>
+    <td>Sets the size of the queue which is used for holding tasks to be executed.</td>
+    <td><code>3</code></td>
+  </tr>
+</table>
 
 ## Datasource
 
-Limitations for CockroachDB
+If not default Quarkus datasource is configured, the Camunda Quarkus extension sets an embedded (local) H2 database as 
+the primary/default Quarkus datasource.
+
+### Using Quarkus Transaction Integration with CockroachDB
+
+Quarkus allows its users to control transaction boundaries. This is documented in their [Quarkus Transactions][quarkus-transactions] 
+page. In case you use the Quarkus Transactions Integration with CockroachDB, please see the documentation section on 
+[external transaction management with CockroachDB][crdb-transactions] to understand how to configure the Camunda process
+engine correctly.
+
+## Example
+
+The following is an example of a Quarkus `application.properties` file that provides custom values for the process 
+engine configuration, job executor and data source:
+
+```properties
+# process engine configuration
+quarkus.camunda.cmmn-enabled=false
+quarkus.camunda.dmn-enabled=false
+quarkus.camunda.history=none
+quarkus.camunda.initialize-telemetry=false
+
+# job executor configuration
+quarkus.camunda.job-executor.thread-pool.max-pool-size=12
+quarkus.camunda.job-executor.thread-pool.queue-size=5
+quarkus.camunda.job-executor.max-jobs-per-acquisition=5
+quarkus.camunda.job-executor.lock-time-in-millis=500000
+quarkus.camunda.job-executor.wait-time-in-millis=7000
+quarkus.camunda.job-executor.max-wait=65000
+quarkus.camunda.job-executor.backoff-time-in-millis=5
+
+# custom data source configuration and selection
+quarkus.datasource.camunda.db-kind=h2
+quarkus.datasource.camunda.username=camunda
+quarkus.datasource.camunda.password=camunda
+quarkus.datasource.camunda.jdbc.url=jdbc:h2:mem:camunda;MVCC=TRUE;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE
+quarkus.camunda.datasource=camunda
+```
+
+[crdb-transactions]: {{< ref "/user-guide/process-engine/database/cockroachdb-configuration.md#using-external-transaction-management-with-the-spring-java-ee-integrations" >}}
+[engine-properties]: {{< ref "/reference/deployment-descriptors/tags/process-engine.md#configuration-properties" >}}
+[executor-properties]: {{< ref "/reference/deployment-descriptors/tags/job-executor.md#job-acquisition-configuration-properties" >}}
+[db-schema-update]: {{< ref "/user-guide/process-engine/database/database-configuration.md#example-database-configuration" >}}
+
+[quarkus-datasource]: https://quarkus.io/guides/datasource
+[quarkus-transactions]: https://quarkus.io/guides/transaction#declarative-approach
+[quarkus-cdi]: https://quarkus.io/guides/cdi-reference
+[quarkus-config]: https://quarkus.io/guides/config-reference
+[mp-config]: https://www.eclipse.org/community/eclipse_newsletter/2017/september/article3.php

--- a/content/user-guide/quarkus-integration/configuration.md
+++ b/content/user-guide/quarkus-integration/configuration.md
@@ -31,7 +31,7 @@ A `QuarkusProcessEngineConfiguration` instance provides the following defaults:
   </tr>
 
   <tr>
-    <td rowspan="1"><code>jobExecutorActivate</code></td>
+    <td><code>jobExecutorActivate</code></td>
     <td>
       The job executor is activated.
     </td>
@@ -39,7 +39,7 @@ A `QuarkusProcessEngineConfiguration` instance provides the following defaults:
   </tr>
 
   <tr>
-    <td rowspan="1"><code>transactionsExternallyManaged</code></td>
+    <td><code>transactionsExternallyManaged</code></td>
     <td>
       Transactions are externally managed.
     </td>
@@ -47,7 +47,7 @@ A `QuarkusProcessEngineConfiguration` instance provides the following defaults:
   </tr>
 
   <tr>
-    <td rowspan="1"><code>databaseSchemaUpdate</code></td>
+    <td><code>databaseSchemaUpdate</code></td>
     <td>
       The <a href="{{< ref "/user-guide/process-engine/database/database-configuration.md#example-database-configuration" >}}">Database Configuration</a> 
       section goes into more details on this propery and the resulting behavior.
@@ -56,7 +56,7 @@ A `QuarkusProcessEngineConfiguration` instance provides the following defaults:
   </tr>
 
   <tr>
-    <td rowspan="1"><code>idGenerator</code></td>
+    <td><code>idGenerator</code></td>
     <td>
       An instance of {{< javadocref page="?org/camunda/bpm/engine/impl/persistence/StrongUuidGenerator.html" text="StrongUuidGenerator" >}}
       is used.
@@ -65,23 +65,16 @@ A `QuarkusProcessEngineConfiguration` instance provides the following defaults:
   </tr>
 
   <tr>
-    <td rowspan="1"><code>jdbcUrl</code></td>
-    <td rowspan="4">
+    <td>
+      <code>jdbcUrl</code>,<br> 
+      <code>jdbcUsername</code>,<br>
+      <code>jdbcPassword</code>,<br>
+      <code>jdbcDriver</code>
+    </td>
+    <td>
       No JDBC configuration is present since a Quarkus datasource should be configured and used.
     </td>
-    <td rowspan="4"><code>null</code></td>
-  </tr>
-
-  <tr>
-    <td rowspan="1"><code>jdbcUsername</code></td>
-  </tr>
-
-  <tr>
-    <td rowspan="1"><code>jdbcPassword</code></td>
-  </tr>
-
-  <tr>
-    <td rowspan="1"><code>jdbcDriver</code></td>
+    <td><code>null</code></td>
   </tr>
 
 </table>
@@ -106,21 +99,13 @@ quarkus.camunda.initialize-telemetry=false
 You can also configure the process engine programmatically, by providing a `QuarkusProcessEngineConfiguration` CDI bean.
 
 ```java
-  @ApplicationScoped
-  static class MyConfig {
-
-    @Produces
-    public QuarkusProcessEngineConfiguration customEngineConfig() {
-
-      QuarkusProcessEngineConfiguration engineConfig = new QuarkusProcessEngineConfiguration();
-      
-      // your custom configuration is done here
-      engineConfig.setProcessEngineName("customEngine");
-
-      return engineConfig;
-    }
-
+@ApplicationScoped
+public class MyCustomEngineConfig extends QuarkusProcessEngineConfiguration {
+  public MyCustomEngineConfig() {
+    // your custom configuration is done here
+    setProcessEngineName("customEngine");
   }
+}
 ```
 
 Note that values of properties set in a `QuarkusProcessEngineConfiguration` instance have a lower ordinal than

--- a/content/user-guide/quarkus-integration/configuration.md
+++ b/content/user-guide/quarkus-integration/configuration.md
@@ -23,17 +23,68 @@ Camunda Process Engine Configuration properties.
 An instance of the `QuarkusProcessEngineConfiguration` class configures the process engine in a Quarkus application. 
 A `QuarkusProcessEngineConfiguration` instance provides the following defaults:
 
-* The job executor is activated by default, i.e. the `jobExecutorActivate` property is set to `true`.
-* Transactions are externally managed by default since the `transactionsExternallyManaged` is set to `true`.
-* The `databaseSchemaUpdate` property is set to `true`. The [Database Configuration][db-schema-update] section goes into 
-  more details on this propery and the resulting behavior.
-* No JDBC configuration is present since a Quarkus datasource should be configured and used. As a result, the following
-  properties are set to `null`:
-  * `jdbcUrl`
-  * `jdbcUsername`
-  * `jdbcPassword`
-  * `jdbcDriver`
-* The `idGenerator` is set to an instance of {{< javadocref page="?org/camunda/bpm/engine/impl/persistence/StrongUuidGenerator.html" text="StrongUuidGenerator" >}}.
+<table class="table desc-table">
+  <tr>
+    <th>Property name</th>
+    <th>Description</th>
+    <th>Default value</th>
+  </tr>
+
+  <tr>
+    <td rowspan="1"><code>jobExecutorActivate</code></td>
+    <td>
+      The job executor is activated.
+    </td>
+    <td><code>true</code></td>
+  </tr>
+
+  <tr>
+    <td rowspan="1"><code>transactionsExternallyManaged</code></td>
+    <td>
+      Transactions are externally managed.
+    </td>
+    <td><code>true</code></td>
+  </tr>
+
+  <tr>
+    <td rowspan="1"><code>databaseSchemaUpdate</code></td>
+    <td>
+      The <a href="{{< ref "/user-guide/process-engine/database/database-configuration.md#example-database-configuration" >}}">Database Configuration</a> 
+      section goes into more details on this propery and the resulting behavior.
+    </td>
+    <td><code>true</code></td>
+  </tr>
+
+  <tr>
+    <td rowspan="1"><code>idGenerator</code></td>
+    <td>
+      An instance of {{< javadocref page="?org/camunda/bpm/engine/impl/persistence/StrongUuidGenerator.html" text="StrongUuidGenerator" >}}
+      is used.
+    </td>
+    <td><code>StrongUuidGenerator</code></td>
+  </tr>
+
+  <tr>
+    <td rowspan="1"><code>jdbcUrl</code></td>
+    <td rowspan="4">
+      No JDBC configuration is present since a Quarkus datasource should be configured and used.
+    </td>
+    <td rowspan="4"><code>null</code></td>
+  </tr>
+
+  <tr>
+    <td rowspan="1"><code>jdbcUsername</code></td>
+  </tr>
+
+  <tr>
+    <td rowspan="1"><code>jdbcPassword</code></td>
+  </tr>
+
+  <tr>
+    <td rowspan="1"><code>jdbcDriver</code></td>
+  </tr>
+
+</table>
 
 Quarkus allows to configure a Quarkus application via a [MicroProfile Config][mp-config] source. You can read more about 
 configuring a Quarkus application in the [Quarkus configuration][quarkus-config] page. The Camunda Quarkus extension 
@@ -50,7 +101,7 @@ quarkus.camunda.history=none
 quarkus.camunda.initialize-telemetry=false
 ```
 
-### Programmatic Process Engine Configuration
+### Programmatic Configuration
 
 You can also configure the process engine programmatically, by providing a `QuarkusProcessEngineConfiguration` CDI bean.
 
@@ -101,7 +152,7 @@ quarkus.camunda.job-executor.max-wait=65000
 
 ## Quarkus Extension Configuration
 
-In addition to the general process engine, and job executor, configuration properties mentioned in the previous 
+In addition to the general process engine and job executor configuration properties mentioned in the previous 
 sections, the Camunda Quarkus extension provides some Quarkus-specific configuration properties. They can be set
 through a Quarkus config source, but not through the `QuarkusProcessEngineConfiguration` class. You can find all
 the Quarkus-specific properties in the following table:
@@ -121,7 +172,8 @@ the Quarkus-specific properties in the following table:
     <td><code>.datasource</code></td>
     <td>
       Specifies which Quarkus datasource to use. If not defined, the primary Quarkus datasource will be used. 
-      For configuring a Quarkus Datasource, have a look on the [Quarkus Datasource][quarkus-datasource] page.
+      For configuring a Quarkus Datasource, have a look on the 
+      <a href="https://quarkus.io/guides/datasource">Quarkus Datasource</a> page.
     </td>
     <td><code>&#60;default&#62;</code></td>
   </tr>
@@ -144,8 +196,8 @@ the Quarkus-specific properties in the following table:
 
 ## Datasource
 
-If not default Quarkus datasource is configured, the Camunda Quarkus extension sets an embedded (local) H2 database as 
-the primary/default Quarkus datasource.
+If no default Quarkus datasource is configured, the Camunda Quarkus extension sets an embedded (local) on-disk H2 
+database as the primary/default Quarkus datasource.
 
 ### Using Quarkus Transaction Integration with CockroachDB
 
@@ -176,17 +228,16 @@ quarkus.camunda.job-executor.max-wait=65000
 quarkus.camunda.job-executor.backoff-time-in-millis=5
 
 # custom data source configuration and selection
-quarkus.datasource.camunda.db-kind=h2
-quarkus.datasource.camunda.username=camunda
-quarkus.datasource.camunda.password=camunda
-quarkus.datasource.camunda.jdbc.url=jdbc:h2:mem:camunda;MVCC=TRUE;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE
-quarkus.camunda.datasource=camunda
+quarkus.datasource.my-datasource.db-kind=h2
+quarkus.datasource.my-datasource.username=camunda
+quarkus.datasource.my-datasource.password=camunda
+quarkus.datasource.my-datasource.jdbc.url=jdbc:h2:mem:camunda;MVCC=TRUE;TRACE_LEVEL_FILE=0;DB_CLOSE_ON_EXIT=FALSE
+quarkus.camunda.datasource=my-datasource
 ```
 
 [crdb-transactions]: {{< ref "/user-guide/process-engine/database/cockroachdb-configuration.md#using-external-transaction-management-with-the-spring-java-ee-integrations" >}}
 [engine-properties]: {{< ref "/reference/deployment-descriptors/tags/process-engine.md#configuration-properties" >}}
 [executor-properties]: {{< ref "/reference/deployment-descriptors/tags/job-executor.md#job-acquisition-configuration-properties" >}}
-[db-schema-update]: {{< ref "/user-guide/process-engine/database/database-configuration.md#example-database-configuration" >}}
 
 [quarkus-datasource]: https://quarkus.io/guides/datasource
 [quarkus-transactions]: https://quarkus.io/guides/transaction#declarative-approach


### PR DESCRIPTION
* This page documents the configuration options for an embedded process engine in a Quarkus application. It covers configuration methods for a process engine, job executor, and data source.

Related to CAM-13835

:information_source: This PR is based on the CAM-13638 branch.