### PR TITLE
CAM-13874: mention new template engine versions

### DIFF
--- a/content/installation/full/tomcat/manual.md
+++ b/content/installation/full/tomcat/manual.md
@@ -251,7 +251,7 @@ Add the following artifacts (if not existing) from the folder `$TOMCAT_DISTRIBUT
 Add the following artifacts (if not existing) from the folder `$TOMCAT_DISTRIBUTION/lib/` to the folder `$TOMCAT_HOME/lib/`:
 
 * `camunda-template-engines-freemarker-$TEMPLATE_VERSION.jar`
-* `freemarker-2.3.29.jar`
+* `freemarker-2.3.31.jar`
 * `camunda-commons-utils-$COMMONS_VERSION.jar`
 
 ## GraalVM JavaScript Integration

--- a/content/installation/full/was/manual.md
+++ b/content/installation/full/was/manual.md
@@ -367,14 +367,6 @@ Add the following artifacts (if not existing) from the folder `$WAS_DISTRIBUTION
 * `groovy-all-$GROOVY_VERSION.jar`
 
 
-## Freemarker Integration
-
-Add the following artifacts (if not existing) from the folder `$WAS_DISTRIBUTION/modules/lib/` to the `Camunda` shared library folder:
-
-* `camunda-template-engines-freemarker-$TEMPLATE_VERSION.jar`
-* `freemarker-2.3.29.jar`
-* `camunda-commons-utils-$COMMONS_VERSION.jar`
-
 ## GraalVM JavaScript Integration
 
 Add the following artifacts (if not existing) from the folder `$WAS_DISTRIBUTION/modules/lib/` to the `Camunda` shared library folder:

--- a/content/update/minor/715-to-716/_index.md
+++ b/content/update/minor/715-to-716/_index.md
@@ -21,6 +21,7 @@ This document guides you through the update from Camunda Platform `7.15.x` to `7
 1. For administrators: [Set Variables on Process Instance Migration](#set-variables-on-process-instance-migration)
 1. For administrators: [Java 15 and GraalVM JavaScript support](#java-15-and-graalvm-javascript-support)
 1. For administrators: [Upcoming Liquibase support](#upcoming-liquibase-support)
+1. For administrators and developers: [New Version of Templating Engines (Freemarker, Velocity)](#new-version-of-templating-engines-freemarker-velocity)
 
 This guide covers mandatory migration steps as well as optional considerations for the initial configuration of new functionality included in Camunda Platform 7.16.
 
@@ -205,3 +206,20 @@ an exception as the definition could not be parsed correctly.
 Starting with Camunda Platform `7.16.0`, Liquibase can be used to [install the database schema]({{< ref "/installation/database-schema.md" >}}) and keep track of necessary changes to it.
 However, Liquibase can *NOT* be used to update from `7.15.x` to `7.16`. Please use the [manual update approach]({{< ref "/installation/database-schema.md#manual-update" >}}) for that.
 Nonetheless, you can already [migrate to Liquibase]({{< ref "/installation/database-schema.md#migrate-to-liquibase" >}}) as soon as you updated to `7.16.0` and prepare your installation for any future updates.
+
+# New Version of Templating Engines (Freemarker, Velocity)
+
+Camunda 7.16 includes version 2.1.0 of the `org.camunda.template-engines` artifacts, in particular `camunda-template-engines-freemarker`, `camunda-template-engines-velocity` and `camunda-template-engines-xquery-saxon`.
+
+This updates the following template engine versions:
+
+* Apache Freemarker
+  * Old version: 2.3.29 (Release date: August 2019)
+  * New version: 2.3.31 (Release date: February 2021)
+  * Change log: https://freemarker.apache.org/docs/api/freemarker/template/Configuration.html#Configuration-freemarker.template.Version-
+* Apache Velocity
+  * Old version: 2.2 (Release date: January 2020)
+  * New version: 2.3 (Release date: March 2021)
+  * Change log: https://velocity.apache.org/engine/2.3/upgrading.html
+  
+Please note that the new version of Freemarker contains changes that are not compatible with the previous version. We strongly recommend to test the execution of your templates before applying the update. In addition, you can replace the artifacts of version 2.1.0 by the old artifacts in version 2.0.0 to continue using the old versions of Freemarker and Velocity.

--- a/content/update/minor/715-to-716/_index.md
+++ b/content/update/minor/715-to-716/_index.md
@@ -209,7 +209,7 @@ Nonetheless, you can already [migrate to Liquibase]({{< ref "/installation/datab
 
 # New Version of Templating Engines (Freemarker, Velocity)
 
-Camunda 7.16 includes version 2.1.0 of the `org.camunda.template-engines` artifacts, in particular `camunda-template-engines-freemarker`, `camunda-template-engines-velocity` and `camunda-template-engines-xquery-saxon`.
+Camunda 7.16 includes version 2.1.0 of the `org.camunda.template-engines` artifacts, in particular `camunda-template-engines-freemarker`, `camunda-template-engines-velocity`, and `camunda-template-engines-xquery-saxon`.
 
 This updates the following template engine versions:
 

--- a/content/update/patch-level.md
+++ b/content/update/patch-level.md
@@ -264,7 +264,7 @@ this, with `DB-DRIVER-CLASS`, `JDBC-URL`, `DB-USER`, and `DB-PASSWORD` replaced 
 
 ## 7.15.5 to 7.15.6 / 7.14.11 to 7.14.12 / 7.13.17 to 7.13.18
 
-The patches include version 2.1.0 of the `org.camunda.template-engines` artifacts, in particular `camunda-template-engines-freemarker`, `camunda-template-engines-velocity` and `camunda-template-engines-xquery-saxon`.
+The patches include version 2.1.0 of the `org.camunda.template-engines` artifacts, in particular `camunda-template-engines-freemarker`, `camunda-template-engines-velocity`, and `camunda-template-engines-xquery-saxon`.
 
 This updates the following template engine versions:
 

--- a/content/update/patch-level.md
+++ b/content/update/patch-level.md
@@ -262,6 +262,23 @@ this, with `DB-DRIVER-CLASS`, `JDBC-URL`, `DB-USER`, and `DB-PASSWORD` replaced 
 </bean>
 ```
 
+## 7.15.5 to 7.15.6 / 7.14.11 to 7.14.12 / 7.13.17 to 7.13.18
+
+The patches include version 2.1.0 of the `org.camunda.template-engines` artifacts, in particular `camunda-template-engines-freemarker`, `camunda-template-engines-velocity` and `camunda-template-engines-xquery-saxon`.
+
+This updates the following template engine versions:
+
+* Apache Freemarker
+  * Old version: 2.3.29 (Release date: August 2019)
+  * New version: 2.3.31 (Release date: February 2021)
+  * Change log: https://freemarker.apache.org/docs/api/freemarker/template/Configuration.html#Configuration-freemarker.template.Version-
+* Apache Velocity
+  * Old version: 2.2 (Release date: January 2020)
+  * New version: 2.3 (Release date: March 2021)
+  * Change log: https://velocity.apache.org/engine/2.3/upgrading.html
+  
+Please note that the new version of Freemarker contains changes that are not compatible with the previous version. We strongly recommend to test the execution of your templates before applying the update. In addition, you can replace the artifacts of version 2.1.0 by the old artifacts in version 2.0.0 to continue using the old versions of Freemarker and Velocity.
+
 # Full Distribution
 
 This section is applicable if you installed the [Full Distribution]({{< ref "/introduction/downloading-camunda.md#full-distribution" >}}) with a **shared process engine**. In this case you need to update the libraries and applications installed inside the application server.


### PR DESCRIPTION
- also updates the installation guide to reference the freemarker version
- removes the freemarker installation steps for WAS shared distro.
  Freemarker was never distributed as part of the WAS distribution,
  so this section was never technically possible

related to CAM-13874