### PR TITLE
CAM-13874: mention new template engine versions

### DIFF
--- a/content/installation/full/tomcat/manual.md
+++ b/content/installation/full/tomcat/manual.md
@@ -272,5 +272,5 @@ Add the following artifacts (if not existing) from the folder `$TOMCAT_DISTRIBUT
 Add the following artifacts (if not existing) from the folder `$TOMCAT_DISTRIBUTION/lib/` to the folder `$TOMCAT_HOME/lib/`:
 
 * `camunda-template-engines-freemarker-$TEMPLATE_VERSION.jar`
-* `freemarker-2.3.29.jar`
+* `freemarker-2.3.31.jar`
 * `camunda-commons-utils-$COMMONS_VERSION.jar`

--- a/content/installation/full/was/manual.md
+++ b/content/installation/full/was/manual.md
@@ -382,15 +382,6 @@ Add the following artifacts (if not existing) from the folder `$WAS_DISTRIBUTION
 * `groovy-all-$GROOVY_VERSION.jar`
 
 
-## Freemarker Integration
-
-Add the following artifacts (if not existing) from the folder `$WAS_DISTRIBUTION/modules/lib/` to the `Camunda` shared library folder:
-
-* `camunda-template-engines-freemarker-$TEMPLATE_VERSION.jar`
-* `freemarker-2.3.29.jar`
-* `camunda-commons-utils-$COMMONS_VERSION.jar`
-
-
 # Process Applications
 
 After installing a Process Application (PA) in your IBM WebSphere Application Server, which **does not** include the Camunda Platform dependencies,

--- a/content/update/patch-level.md
+++ b/content/update/patch-level.md
@@ -708,7 +708,7 @@ this, with `DB-DRIVER-CLASS`, `JDBC-URL`, `DB-USER`, and `DB-PASSWORD` replaced 
 
 ## 7.14.11 to 7.14.12 / 7.13.17 to 7.13.18
 
-The patches include version 2.1.0 of the `org.camunda.template-engines` artifacts, in particular `camunda-template-engines-freemarker`, `camunda-template-engines-velocity` and `camunda-template-engines-xquery-saxon`.
+The patches include version 2.1.0 of the `org.camunda.template-engines` artifacts, in particular `camunda-template-engines-freemarker`, `camunda-template-engines-velocity`, and `camunda-template-engines-xquery-saxon`.
 
 This updates the following template engine versions:
 

--- a/content/update/patch-level.md
+++ b/content/update/patch-level.md
@@ -706,6 +706,23 @@ this, with `DB-DRIVER-CLASS`, `JDBC-URL`, `DB-USER`, and `DB-PASSWORD` replaced 
 </bean>
 ```
 
+## 7.14.11 to 7.14.12 / 7.13.17 to 7.13.18
+
+The patches include version 2.1.0 of the `org.camunda.template-engines` artifacts, in particular `camunda-template-engines-freemarker`, `camunda-template-engines-velocity` and `camunda-template-engines-xquery-saxon`.
+
+This updates the following template engine versions:
+
+* Apache Freemarker
+  * Old version: 2.3.29 (Release date: August 2019)
+  * New version: 2.3.31 (Release date: February 2021)
+  * Change log: https://freemarker.apache.org/docs/api/freemarker/template/Configuration.html#Configuration-freemarker.template.Version-
+* Apache Velocity
+  * Old version: 2.2 (Release date: January 2020)
+  * New version: 2.3 (Release date: March 2021)
+  * Change log: https://velocity.apache.org/engine/2.3/upgrading.html
+  
+Please note that the new version of Freemarker contains changes that are not compatible with the previous version. We strongly recommend to test the execution of your templates before applying the update. In addition, you can replace the artifacts of version 2.1.0 by the old artifacts in version 2.0.0 to continue using the old versions of Freemarker and Velocity.
+
 # Full Distribution
 
 This section is applicable if you installed the [Full Distribution]({{< ref "/introduction/downloading-camunda.md#full-distribution" >}}) with a **shared process engine**. In this case you need to update the libraries and applications installed inside the application server.


### PR DESCRIPTION
- also updates the installation guide to reference the freemarker version
- removes the freemarker installation steps for WAS shared distro.
  Freemarker was never distributed as part of the WAS distribution,
  so this section was never technically possible

related to CAM-13874