### PR TITLE
Fixed 'Embeded' typo

### DIFF
--- a/content/reference/forms/embedded-forms/_index.md
+++ b/content/reference/forms/embedded-forms/_index.md
@@ -6,7 +6,7 @@ layout: "single"
 
 menu:
   main:
-    name: "Embeded Forms"
+    name: "Embedded Forms"
     identifier: "embedded-forms-ref"
     parent: "forms-ref"
     pre: "Custom HTML Forms embeddable in Tasklist"


### PR DESCRIPTION
Updated _index.md in content/reference/forms/embedded-forms to fix typo in navigation pane