### PR TITLE
CAM-14370: remove incorrect closing tag

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -146,7 +146,6 @@
         Browse the <a href="https://github.com/camunda-community-hub">Camunda Community Hub</a> for information on <a href="https://github.com/camunda-community-hub/community#creating-a-new-camunda-community-extension">building a Camunda Community Extension</a>, 
         discover new Camunda Community Extension open source projects to contribute to, and more.</p>
         </header>
-        </div>
       </section>
     </div>
   </div>


### PR DESCRIPTION
- fixes markup structure so that div #page-toc becomes a child element
  of #page-wrapper again
- this makes the banner links clickable again

related to CAM-14370