### PR TITLE
CAM-14302: doc(upgrade): adjust groovy version bump guide

### DIFF
--- a/content/update/minor/717-to-718/_index.md
+++ b/content/update/minor/717-to-718/_index.md
@@ -73,15 +73,15 @@ Take the following steps to complete the update:
 # Groovy version update
 
 Camunda Platform 7 provides the Groovy script engine by default with the pre-packaged distributions. With Camunda Platform
-7.18, we bumped Groovy to version `2.5.16`. This version of Groovy [doesn't provide a `groovy-all.jar` anymore](https://groovy-lang.org/releasenotes/groovy-2.5.html). Therefore, you will find the following Groovy-related libraries in the Camunda Platform 7.18 pre-packed distributions:
+7.18, we bumped Groovy to version `2.4.21`. With this Groovy version bump, we decided to move away from the `groovy-all-$GROOVY_VERSION.jar` 
+since newer Groovy versions [don't provide a `groovy-all-$GROOVY_VERSION.jar` anymore](https://groovy-lang.org/releasenotes/groovy-2.5.html).
+Therefore, you will find the following Groovy-related libraries in the Camunda Platform 7.18 pre-packed distributions:
 
 * `groovy-$GROOVY_VERSION.jar`
 * `groovy-jsr223-$GROOVY_VERSION.jar`
 * `groovy-json-$GROOVY_VERSION.jar`
 * `groovy-xml-$GROOVY_VERSION.jar`
 * `groovy-templates-$GROOVY_VERSION.jar`
-* `groovy-datetime-$GROOVY_VERSION.jar`
-* `groovy-dateutil-$GROOVY_VERSION.jar`
 
 The `groovy` and `groovy-jsr-223` Groovy modules are required for correct operation of the Groovy script engine.
 Since the `groovy-all.jar` included a lot more than `groovy` and `groovy-jsr-223` modules, we decided to provide additional useful Groovy modules.

--- a/content/update/minor/717-to-718/tomcat.md
+++ b/content/update/minor/717-to-718/tomcat.md
@@ -91,8 +91,6 @@ The following libraries replace the single `groovy-all-$GROOVY_VERSION.jar` libr
 * `groovy-json-$GROOVY_VERSION.jar`
 * `groovy-xml-$GROOVY_VERSION.jar`
 * `groovy-templates-$GROOVY_VERSION.jar`
-* `groovy-datetime-$GROOVY_VERSION.jar`
-* `groovy-dateutil-$GROOVY_VERSION.jar`
 
 # 3. Update web applications
 

--- a/content/update/minor/717-to-718/was.md
+++ b/content/update/minor/717-to-718/was.md
@@ -96,8 +96,6 @@ The following libraries replace the single `groovy-all-$GROOVY_VERSION.jar` libr
 * `groovy-json-$GROOVY_VERSION.jar`
 * `groovy-xml-$GROOVY_VERSION.jar`
 * `groovy-templates-$GROOVY_VERSION.jar`
-* `groovy-datetime-$GROOVY_VERSION.jar`
-* `groovy-dateutil-$GROOVY_VERSION.jar`
 
 # 4. Maintain the Camunda Platform configuration
 

--- a/content/update/minor/717-to-718/wls.md
+++ b/content/update/minor/717-to-718/wls.md
@@ -96,8 +96,6 @@ The following libraries replace the single `groovy-all-$GROOVY_VERSION.jar` libr
 * `groovy-json-$GROOVY_VERSION.jar`
 * `groovy-xml-$GROOVY_VERSION.jar`
 * `groovy-templates-$GROOVY_VERSION.jar`
-* `groovy-datetime-$GROOVY_VERSION.jar`
-* `groovy-dateutil-$GROOVY_VERSION.jar`
 
 # 4. Maintain the Camunda Platform configuration
 


### PR DESCRIPTION
Related to CAM-14302

Unfortunately, we have to downgrade to an earlier Groovy version due to a JDK 17 incompatibility. More details [here](https://jira.camunda.com/browse/CAM-14302?focusedCommentId=233767&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-233767).