### PR TITLE
fix(seo): update theme to incorporate semantic nav element

### DIFF
--- a/themes/camunda/layouts/partials/header.html
+++ b/themes/camunda/layouts/partials/header.html
@@ -94,9 +94,9 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 
 <div class="search-underlay"></div>
 
-<div class="site-menu">
+<nav class="site-menu">
   {{ partialCached "menu.html" . }}
-</div>
+</nav>
 
 
 <div class="page-wrapper">


### PR DESCRIPTION
Updates the theme to incorporate https://github.com/camunda/camunda-docs-theme/pull/29 (in v7.17). 
