### PR TITLE
CAM-14558: chore(release): edit 7.18 update guide

### DIFF
--- a/content/update/minor/717-to-718/_index.md
+++ b/content/update/minor/717-to-718/_index.md
@@ -26,7 +26,7 @@ This document guides you through the update from Camunda Platform `7.17.x` to `7
 1. For developers: [Adjusted class structure for Expression Language handling](#adjusted-class-structure-for-expression-language-handling)
 1. For developers: [Adjusted exception handling in the Java External Task Client](#adjusted-exception-handling-in-the-java-external-task-client)
 1. For administrators: [Batch execution start time](#batch-execution-start-time)
-1. For developers: [Discontinue Camunda H2 console webapp](#discontinue-camunda-h2-console-webapp)
+1. For developers: [Discontinue Camunda H2 console webapp](#discontinue-camunda-h2-console-web-app)
 
 This guide covers mandatory migration steps and optional considerations for the initial configuration of new functionality included in Camunda Platform 7.18.
 

--- a/content/update/minor/717-to-718/jboss.md
+++ b/content/update/minor/717-to-718/jboss.md
@@ -1,17 +1,17 @@
 ---
 
-title: "Update a JBoss EAP 6 or Wildfly / JBoss EAP 7 Installation from 7.17 to 7.18"
+title: "Update a Wildfly / JBoss EAP 7 Installation from 7.17 to 7.18"
 
 menu:
   main:
-    name: "JBoss EAP 6 or Wildfly / JBoss EAP 7"
+    name: "Wildfly / JBoss EAP 7"
     identifier: "migration-guide-718-jboss"
     parent: "migration-guide-718"
 
 ---
 
-The following steps describe how to update the Camunda artifacts on a JBoss EAP 6 or
-Wildfly/JBoss EAP 7 in a shared process engine scenario. Throughout the procedure, refer to the [update guide][update-guide].
+The following steps describe how to update the Camunda artifacts on a Wildfly/JBoss EAP 7 in a 
+shared process engine scenario. Throughout the procedure, refer to the [update guide][update-guide].
 
 If not already done, download the [Camunda Platform 7.18 JBoss distribution](https://downloads.camunda.cloud/release/camunda-bpm/jboss/7.18/)
 or [Camunda Platform 7.18 Wildfly distribution](https://downloads.camunda.cloud/release/camunda-bpm/wildfly/7.18/). In the following instructions,
@@ -97,10 +97,15 @@ Additionally, replace the following dependent modules:
 
 ## Groovy
 
-Replace the following module from the folder `$APP_SERVER_HOME/modules/` with the new version from the 
-folder `$APP_SERVER_DISTRIBUTION/modules/`, if present:
+Replace the 'org/codehaus/groovy/groovy-all' module from the folder `$APP_SERVER_HOME/modules/` with the following 
+modules from the folder `$APP_SERVER_DISTRIBUTION/modules/`, if present:
 
 * `org/codehaus/groovy/groovy-all`
+* `org/codehaus/groovy/groovy`
+* `org/codehaus/groovy/groovy-jsr223`
+* `org/codehaus/groovy/groovy-json`
+* `org/codehaus/groovy/groovy-xml`
+* `org/codehaus/groovy/groovy-templates`
 
 # 3. Update Camunda web applications
 

--- a/content/update/minor/717-to-718/was.md
+++ b/content/update/minor/717-to-718/was.md
@@ -133,7 +133,7 @@ The following steps are required to update the Camunda REST API on an IBM WebSph
   1. Deploy the web application `$WAS_DISTRIBUTION/webapps/camunda-engine-rest-{{< minor-version >}}.0-ee-was.war` to your IBM WebSphere instance.
   2. Associate the web application with the `Camunda` shared library.
 * On WebSphere Liberty:
-  1. Place the web application `$WAS_DISTRIBUTION/webapps/camunda-engine-rest-{{< minor-version >}}.0-ee-was.war` on you Liberty `$YOUR_SERVER/apps/` directory/.
+  1. Place the web application `$WAS_DISTRIBUTION/webapps/camunda-engine-rest-{{< minor-version >}}.0-ee-was.war` in the Liberty `$YOUR_SERVER/apps/` directory.
   2. Configure the `server.xml` as described in [the Liberty installation guide]({{< ref "installation/full/was/manual-liberty.md#rest-api" >}}).
 
 ## Cockpit, Tasklist, and Admin

--- a/content/update/minor/717-to-718/was.md
+++ b/content/update/minor/717-to-718/was.md
@@ -144,7 +144,7 @@ The following steps are required to update the Camunda web applications Cockpit,
   1. Deploy the web application `$WAS_DISTRIBUTION/webapps/camunda-webapp-ee-was-{{< minor-version >}}.0-ee.war` to your IBM WebSphere instance.
   2. Associate the web application with the `Camunda` shared library.
 * On WebSphere Liberty:
-  1. Place the web application `$WAS_DISTRIBUTION/webapps/camunda-webapp-ee-was-{{< minor-version >}}.0-ee.war` on you Liberty `$YOUR_SERVER/apps/` directory/.
+  1. Place the web application `$WAS_DISTRIBUTION/webapps/camunda-webapp-ee-was-{{< minor-version >}}.0-ee.war` in the Liberty `$YOUR_SERVER/apps/` directory.
   2. Configure the `server.xml` as described in [the Liberty installation guide]({{< ref "installation/full/was/manual-liberty.md#cockpit-tasklist-and-admin" >}}).
 
 [configuration-location]: {{< ref "/reference/deployment-descriptors/descriptors/bpm-platform-xml.md" >}}

--- a/content/update/minor/717-to-718/was.md
+++ b/content/update/minor/717-to-718/was.md
@@ -11,7 +11,9 @@ menu:
 ---
 
 
-The following steps describe how to update the Camunda artifacts on an IBM WebSphere application server in a shared process engine setting. Throughout the procedure, refer to the [update guide][update-guide]. If not already done, download the [Camunda Platform 7.18 IBM WebSphere distribution](https://artifacts.camunda.com/artifactory/camunda-bpm-ee/org/camunda/bpm/websphere/camunda-bpm-websphere/7.18.0-ee/).
+The following steps describe how to update the Camunda artifacts on an IBM WebSphere application server 9 or
+IBM WebSphere application server Liberty in a shared process engine setting. Throughout the procedure, refer 
+to the [update guide][update-guide]. If not already done, download the [Camunda Platform 7.18 IBM WebSphere distribution](https://artifacts.camunda.com/artifactory/camunda-bpm-ee/org/camunda/bpm/websphere/camunda-bpm-websphere9/7.18.0-ee/).
 
 The update procedure takes the following steps:
 
@@ -22,31 +24,40 @@ The update procedure takes the following steps:
 5. Install the Camunda Archive.
 6. Install the web applications.
 
-In each of the following steps, the identifier `$*_VERSION` refers to the current versions and the new versions of the artifacts.
+In each of the following steps, the identifier `$*_VERSION` refers to the current versions and the new versions of 
+the artifacts.
 
 # 1. Uninstall the Camunda libraries and archives
 
-First, uninstall the Camunda web applications, namely the Camunda REST API (artifact name like `camunda-engine-rest`) and the Camunda applications Cockpit, Tasklist, and Admin (artifact name like `camunda-webapp`).
+First, uninstall the Camunda web applications, namely the Camunda REST API (artifact name like `camunda-engine-rest`) 
+and the Camunda applications Cockpit, Tasklist, and Admin (artifact name like `camunda-webapp`).
 
-Uninstall the Camunda EAR; its name should be `camunda-ibm-websphere-ear-$PLATFORM_VERSION.ear`.
+Uninstall the Camunda EAR; its name should be `camunda-ibm-websphere-ear-{{< minor-version >}}.0-ee.ear`.
+
+{{< note title="WebSphere Liberty steps" class="info" >}}
+If you are using WebSphere Liberty, you just need to remove the Camunda EAR, REST API, and web applications from the
+Liberty `$YOUR_SERVER/apps/` directory.
+{{< /note >}}
 
 # 2. Replace Camunda core libraries
 
-With your first Camunda installation or update to 7.2, you have created a shared library named `Camunda`. We identify the folder to this shared library as `$SHARED_LIBRARY_PATH`.
+With your first Camunda installation or update to 7.2, you have created a shared library named `Camunda`. We identify 
+the folder to this shared library as `$SHARED_LIBRARY_PATH`.
 
-After shutting down the server, replace the following libraries in `$SHARED_LIBRARY_PATH` with the equivalents from `$WAS_DISTRIBUTION/modules/lib`:
+After shutting down the server, replace the following libraries in `$SHARED_LIBRARY_PATH` with the equivalents 
+from `$WAS_DISTRIBUTION/modules/lib`:
 
-* `camunda-engine-$PLATFORM_VERSION.jar`
-* `camunda-bpmn-model-$PLATFORM_VERSION.jar`
-* `camunda-cmmn-model-$PLATFORM_VERSION.jar`
-* `camunda-dmn-model-$PLATFORM_VERSION.jar`
-* `camunda-xml-model-$PLATFORM_VERSION.jar`
-* `camunda-engine-dmn-$PLATFORM_VERSION.jar`
-* `camunda-engine-feel-api-$PLATFORM_VERSION.jar`
-* `camunda-engine-feel-juel-$PLATFORM_VERSION.jar`
-* `camunda-engine-feel-scala-$PLATFORM_VERSION.jar`
+* `camunda-engine-{{< minor-version >}}.0-ee.jar`
+* `camunda-bpmn-model-{{< minor-version >}}.0-ee.jar`
+* `camunda-cmmn-model-{{< minor-version >}}.0-ee.jar`
+* `camunda-dmn-model-{{< minor-version >}}.0-ee.jar`
+* `camunda-xml-model-{{< minor-version >}}.0-ee.jar`
+* `camunda-engine-dmn-{{< minor-version >}}.0-ee.jar`
+* `camunda-engine-feel-api-{{< minor-version >}}.0-ee.jar`
+* `camunda-engine-feel-juel-{{< minor-version >}}.0-ee.jar`
+* `camunda-engine-feel-scala-{{< minor-version >}}.0-ee.jar`
 * `camunda-commons-logging-$COMMONS_VERSION.jar`
-* `camunda-commons-typed-values-$PLATFORM_VERSION.jar`
+* `camunda-commons-typed-values-{{< minor-version >}}.0-ee.jar`
 * `camunda-commons-utils-$COMMONS_VERSION.jar`
 * `camunda-connect-connectors-all-$CONNECT_VERSION.jar`
 * `camunda-connect-core-$CONNECT_VERSION.jar`
@@ -57,7 +68,8 @@ After shutting down the server, replace the following libraries in `$SHARED_LIBR
 
 # 3. Replace optional Camunda dependencies
 
-In addition to the core libraries, there may be optional artifacts in `$SHARED_LIBRARY_PATH` for LDAP integration, Camunda Spin, Camunda Connect, and scripting. If you use any of these extensions, the following update steps apply:
+In addition to the core libraries, there may be optional artifacts in `$SHARED_LIBRARY_PATH` for LDAP integration, 
+Camunda Spin, Camunda Connect, and scripting. If you use any of these extensions, the following update steps apply:
 
 ## LDAP integration
 
@@ -99,11 +111,17 @@ The following libraries replace the single `groovy-all-$GROOVY_VERSION.jar` libr
 
 # 4. Maintain the Camunda Platform configuration
 
-If you have previously replaced the default Camunda Platform configuration with a custom configuration following any of the methods outlined in the [deployment descriptor reference][configuration-location], it may be necessary to restore this configuration. This can be done by repeating the configuration replacement steps for the updated platform.
+If you have previously replaced the default Camunda Platform configuration with a custom configuration following any of 
+the methods outlined in the [deployment descriptor reference][configuration-location], it may be necessary to restore 
+this configuration. This can be done by repeating the configuration replacement steps for the updated platform.
 
 # 5. Install the Camunda Archive
 
-Install the Camunda EAR, or the file `$WAS_DISTRIBUTION/modules/camunda-ibm-websphere-ear-$PLATFORM_VERSION.ear`. During the installation, the EAR will try to reference the `Camunda` shared library.
+Install the Camunda EAR, or the file `$WAS_DISTRIBUTION/modules/camunda-ibm-websphere-ear-{{< minor-version >}}.0-ee.ear`.
+
+* During the installation on WebSphere 9, the EAR will try to reference the `Camunda` shared library.
+* On WebSphere Liberty, please follow [the EAR installation guide]({{< ref "installation/full/was/manual-liberty.md#camunda-platform-ear" >}}) 
+to deploy the Camunda EAR correctly.
 
 # 6. Install the web applications
 
@@ -111,15 +129,23 @@ Install the Camunda EAR, or the file `$WAS_DISTRIBUTION/modules/camunda-ibm-webs
 
 The following steps are required to update the Camunda REST API on an IBM WebSphere instance:
 
-1. Deploy the web application `$WAS_DISTRIBUTION/webapps/camunda-engine-rest-$PLATFORM_VERSION-was.war` to your IBM WebSphere instance.
-2. Associate the web application with the `Camunda` shared library.
+* On WebSphere 9:
+  1. Deploy the web application `$WAS_DISTRIBUTION/webapps/camunda-engine-rest-{{< minor-version >}}.0-ee-was.war` to your IBM WebSphere instance.
+  2. Associate the web application with the `Camunda` shared library.
+* On WebSphere Liberty:
+  1. Place the web application `$WAS_DISTRIBUTION/webapps/camunda-engine-rest-{{< minor-version >}}.0-ee-was.war` on you Liberty `$YOUR_SERVER/apps/` directory/.
+  2. Configure the `server.xml` as described in [the Liberty installation guide]({{< ref "installation/full/was/manual-liberty.md#rest-api" >}}).
 
 ## Cockpit, Tasklist, and Admin
 
 The following steps are required to update the Camunda web applications Cockpit, Tasklist, and Admin on an IBM WebSphere instance:
 
-1. Deploy the web application `$WAS_DISTRIBUTION/webapps/camunda-webapp-ee-was-$PLATFORM_VERSION.war` to your IBM WebSphere instance.
-2. Associate the web application with the `Camunda` shared library.
+* On WebSphere 9:
+  1. Deploy the web application `$WAS_DISTRIBUTION/webapps/camunda-webapp-ee-was-{{< minor-version >}}.0-ee.war` to your IBM WebSphere instance.
+  2. Associate the web application with the `Camunda` shared library.
+* On WebSphere Liberty:
+  1. Place the web application `$WAS_DISTRIBUTION/webapps/camunda-webapp-ee-was-{{< minor-version >}}.0-ee.war` on you Liberty `$YOUR_SERVER/apps/` directory/.
+  2. Configure the `server.xml` as described in [the Liberty installation guide]({{< ref "installation/full/was/manual-liberty.md#cockpit-tasklist-and-admin" >}}).
 
 [configuration-location]: {{< ref "/reference/deployment-descriptors/descriptors/bpm-platform-xml.md" >}}
 [update-guide]: {{< ref "/update/minor/717-to-718/_index.md" >}}


### PR DESCRIPTION
* Fix the H2 version change link in the update guide.
* Remove JBoss EAP 6 from the docs since we dropped it.
* Fix the download link for the WAS update guide.
* Add update sections for WAS Liberty.

Related to CAM-14558