### PR TITLE
fix: update baseURL so that a valid sitemap is generated

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 ---
-baseURL: "/manual/7.18/"
+baseURL: "https://docs.camunda.org/manual/"
 languageCode: "en-us"
 title: "Camunda Platform 7 documentation"
 theme: "camunda"


### PR DESCRIPTION
While investigating https://github.com/camunda/product-hub/issues/232, we discovered that all of the sitemaps generated by c7 docs are invalid because they include relative URLs instead of absolute.

This PR updates the `baseURL` for v7.18 only, so that we can submit it to Google, in hopes that it resolves our search issues with the c7 docs. 

## Notes

* We're only doing this for 7.18 because we only care about search for the current version.
* We're adding the production domain to the `baseURL`, so that it is included in all sitemap entries.
* We're removing the 7.18 version because we want to submit a sitemap containing what we consider the canonical URLs for all pages. When the version-less URL is browsed, it is redirected to the v7.18 URL, so all of these URLs will eventually resolve to one containing the version. 

## What the sitemap looks like when running a local build with this configuration

```
<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
  xmlns:xhtml="http://www.w3.org/1999/xhtml">
  
  <url>
    <loc>https://docs.camunda.org/manual/reference/rest/process-instance/comment/</loc>
  </url>
  
  <url>
    <loc>https://docs.camunda.org/manual/reference/rest/task/comment/</loc>
  </url>
  
  <url>
    <loc>https://docs.camunda.org/manual/reference/rest/group/members/</loc>
  </url>
  
  <url>
    <loc>https://docs.camunda.org/manual/installation/camunda-modeler/</loc>
  </url>
  
  <url>
    <loc>https://docs.camunda.org/manual/reference/rest/case-execution/local-variables/</loc>
  </url>
  
  <url>
...
```