### PR TITLE
feat: canonicals(7.18) -- correctly fix sitemap & apply rel=canonical strategy to 7.18 branch

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ blackfriday:
   plainIDAnchors: true
 
 params:
+  canonicalBasePath: "https://docs.camunda.org"
   sections:
     - id: "get-started"
       name: "Get Started"

--- a/themes/camunda/layouts/_default/sitemap.xml
+++ b/themes/camunda/layouts/_default/sitemap.xml
@@ -1,0 +1,26 @@
+{{/* This template is overridden to emit permalinks that (1) are absolute, and (2) do not include a version. This allows us to submit the sitemap to crawlers with true canonical URLs. */}}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+  <url>
+    {{- $permalink := .Permalink }}
+    {{- if ($.Site.Params.section.versions) }}
+      {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}
+    {{- end }}
+    <loc>{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink }}"
+                />{{ end }}
+  </url>
+  {{ end }}
+</urlset>

--- a/themes/camunda/layouts/partials/header.html
+++ b/themes/camunda/layouts/partials/header.html
@@ -34,6 +34,7 @@
   {{ $styles := resources.Get "css/docs.css" | fingerprint }}
 
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
+  <link rel="canonical" href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}" />
 </head>
 <body class="{{ .Params.bodyclass }}">
 


### PR DESCRIPTION
Part of https://github.com/camunda/product-hub/issues/232.

This is a second attempt at #1336. 

1. Updates the theme based on https://github.com/camunda/camunda-docs-theme/pull/33
2. Specifies a `canonicalBasePath` config setting for proper sitemap & rel=canonical generation

## Proof that the sitemap gets generated with absolute URLs

I ran a build locally and this is the generated sitemap:

<img width="748" alt="image" src="https://user-images.githubusercontent.com/1627089/201748391-5b0c0991-9add-4c2d-919a-f1d6316f5599.png">

## Proof that pages are generated with a versionless rel=canonical

I ran a build locally and this is the generated page for `/manual/7.18/user-guide/security/`:

<img width="847" alt="image" src="https://user-images.githubusercontent.com/1627089/201748447-df18a725-1f19-42f7-b386-2afc7a78de91.png">
