### PR TITLE
feat: update theme to use versioned canonicals

### DIFF
--- a/themes/camunda/layouts/_default/sitemap.xml
+++ b/themes/camunda/layouts/_default/sitemap.xml
@@ -1,11 +1,13 @@
-{{/* This template is overridden to emit permalinks that (1) are absolute, and (2) do not include a version. This allows us to submit the sitemap to crawlers with true canonical URLs. */}}
+{{/* This template is overridden to emit permalinks that (1) are absolute, and (2) specify the most recent version. This allows us to submit the sitemap to crawlers with true canonical URLs. */}}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
   <url>
     {{- $permalink := .Permalink }}
     {{- if ($.Site.Params.section.versions) }}
-      {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}
+      {{- $latestVersion := (index $.Site.Params.section.versions 1) }}
+      {{- $replacementPattern := print "${1}" $latestVersion "/${3}" }}
+      {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` $replacementPattern }}
     {{- end }}
     <loc>{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}

--- a/themes/camunda/layouts/partials/header.html
+++ b/themes/camunda/layouts/partials/header.html
@@ -34,7 +34,13 @@
   {{ $styles := resources.Get "css/docs.css" | fingerprint }}
 
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
-  <link rel="canonical" href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}" />
+  {{- $permalink := .Permalink }}
+  {{- if ($.Site.Params.section.versions) }}
+    {{- $latestVersion := (index $.Site.Params.section.versions 1) }}
+    {{- $replacementPattern := print "${1}" $latestVersion "/${3}" }}
+    {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` $replacementPattern }}
+  {{- end }}
+  <link rel="canonical" href="{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}" />
 </head>
 <body class="{{ .Params.bodyclass }}">
 


### PR DESCRIPTION
Part of https://github.com/camunda/product-hub/issues/232

Applies the latest-version canonical strategy by pulling in https://github.com/camunda/camunda-docs-theme/pull/35 changes

We will apply this strategy here in 7.18, then submit the sitemap to Google to see if it corrects its old canonicals. Based on those results, we'll then consider if we want to apply these changes to older versions. 

## Proof that it will generate a 7.18 URL in the sitemap

<img width="722" alt="image" src="https://user-images.githubusercontent.com/1627089/204922432-73777506-2459-4f31-87a0-b0110c7c0108.png">


## Proof that it will generate a 7.18 URL in the page head

<img width="780" alt="image" src="https://user-images.githubusercontent.com/1627089/204922372-f31a30cd-e794-4cc4-bc62-76065a602ad9.png">