### PR TITLE
docs(static): remove GSC verified owner file

### DIFF
--- a/static/google936814ef67c9c249.html
+++ b/static/google936814ef67c9c249.html
@@ -1,1 +1,0 @@
-google-site-verification: google936814ef67c9c249.html


### PR DESCRIPTION
Wrong location, verification failed.

Will try to PR camunda-docs-static.