### PR TITLE
seo(7.17): apply versioned canonicals to 7.17

### DIFF
--- a/themes/camunda/layouts/_default/sitemap.xml
+++ b/themes/camunda/layouts/_default/sitemap.xml
@@ -1,11 +1,13 @@
-{{/* This template is overridden to emit permalinks that (1) are absolute, and (2) do not include a version. This allows us to submit the sitemap to crawlers with true canonical URLs. */}}
+{{/* This template is overridden to emit permalinks that (1) are absolute, and (2) specify the most recent version. This allows us to submit the sitemap to crawlers with true canonical URLs. */}}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   {{ range .Data.Pages }}
   <url>
     {{- $permalink := .Permalink }}
     {{- if ($.Site.Params.section.versions) }}
-      {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}
+      {{- $latestVersion := (index $.Site.Params.section.versions 1) }}
+      {{- $replacementPattern := print "${1}" $latestVersion "/${3}" }}
+      {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` $replacementPattern }}
     {{- end }}
     <loc>{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}</loc>{{ if not .Lastmod.IsZero }}
     <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}

--- a/themes/camunda/layouts/partials/header.html
+++ b/themes/camunda/layouts/partials/header.html
@@ -34,7 +34,13 @@
   {{ $styles := resources.Get "css/docs.css" | fingerprint }}
 
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
-  <link rel="canonical" href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` `$1$3` }}" />
+  {{- $permalink := .Permalink }}
+  {{- if ($.Site.Params.section.versions) }}
+    {{- $latestVersion := (index $.Site.Params.section.versions 1) }}
+    {{- $replacementPattern := print "${1}" $latestVersion "/${3}" }}
+    {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` $replacementPattern }}
+  {{- end }}
+  <link rel="canonical" href="{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}" />
 </head>
 <body class="{{ .Params.bodyclass }}">
 


### PR DESCRIPTION
Part of https://github.com/camunda/product-hub/issues/232

Applies the latest-version canonical strategy to v7.17 by pulling in https://github.com/camunda/camunda-docs-theme/pull/35 changes


## Proof that it will generate a 7.18 URL in the sitemap

<img width="637" alt="image" src="https://user-images.githubusercontent.com/1627089/206750741-cf95c2f5-8a85-456e-94dd-fa694dd4892c.png">


## Proof that it will generate a 7.18 URL in the page head

<img width="783" alt="image" src="https://user-images.githubusercontent.com/1627089/206750705-9745ef45-ae17-4d63-9357-20ab03733b58.png">
