### PR TITLE
seo(master) -- apply versioned canonicals to master

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,7 @@ blackfriday:
   plainIDAnchors: true
 
 params:
+  canonicalBasePath: "https://docs.camunda.org"
   sections:
     - id: "get-started"
       name: "Get Started"

--- a/themes/camunda/layouts/_default/sitemap.xml
+++ b/themes/camunda/layouts/_default/sitemap.xml
@@ -1,0 +1,28 @@
+{{/* This template is overridden to emit permalinks that (1) are absolute, and (2) specify the most recent version. This allows us to submit the sitemap to crawlers with true canonical URLs. */}}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+  <url>
+    {{- $permalink := .Permalink }}
+    {{- if ($.Site.Params.section.versions) }}
+      {{- $latestVersion := (index $.Site.Params.section.versions 1) }}
+      {{- $replacementPattern := print "${1}" $latestVersion "/${3}" }}
+      {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` $replacementPattern }}
+    {{- end }}
+    <loc>{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Lang }}"
+                href="{{ $.Site.Params.canonicalBasePath }}{{ .Permalink }}"
+                />{{ end }}
+  </url>
+  {{ end }}
+</urlset>

--- a/themes/camunda/layouts/partials/header.html
+++ b/themes/camunda/layouts/partials/header.html
@@ -34,6 +34,13 @@
   {{ $styles := resources.Get "css/docs.css" | fingerprint }}
 
   <link rel="stylesheet" href="{{ $styles.Permalink }}" integrity="{{ $styles.Data.Integrity }}">
+  {{- $permalink := .Permalink }}
+  {{- if ($.Site.Params.section.versions) }}
+    {{- $latestVersion := (index $.Site.Params.section.versions 1) }}
+    {{- $replacementPattern := print "${1}" $latestVersion "/${3}" }}
+    {{- $permalink = $permalink | replaceRE `(\/manual\/)([^\/]*\/)(.*)` $replacementPattern }}
+  {{- end }}
+  <link rel="canonical" href="{{ $.Site.Params.canonicalBasePath }}{{ $permalink }}" />
 </head>
 <body class="{{ .Params.bodyclass }}">
 


### PR DESCRIPTION
Part of https://github.com/camunda/product-hub/issues/232

Applies the latest-version canonical strategy to v7.17 by pulling in https://github.com/camunda/camunda-docs-theme/pull/35 changes

## Proof that it will generate a 7.18 URL in the sitemap

<img width="628" alt="image" src="https://user-images.githubusercontent.com/1627089/206796215-c3250c3a-1c31-489e-91aa-74586d0d373f.png">


## Proof that it will generate a 7.18 URL in the page head

<img width="739" alt="image" src="https://user-images.githubusercontent.com/1627089/206796259-f2bb3d55-2a59-4df6-b4b0-021c1f3f10dd.png">

