### PR TITLE
docs(fix): update trial and enterprise links for 7.16

### DIFF
--- a/content/introduction/supported-environments.md
+++ b/content/introduction/supported-environments.md
@@ -11,7 +11,7 @@ menu:
 ---
 
 
-Run the Camunda Platform in every Java-runnable environment. Camunda Platform is supported with our QA infrastructure in the following environments. Here you can find more information about our [enterprise support](http://camunda.com/bpm/enterprise/).
+Run the Camunda Platform in every Java-runnable environment. Camunda Platform is supported with our QA infrastructure in the following environments. Here you can find more information about our [enterprise support](http://camunda.com/platform-7/editions/).
 
 {{< note title="Supported Environments" class="info" >}}
   Please note that the environments listed in this section depend on the version of the Camunda Platform. Please select the corresponding version of this documentation to see the environment that fits to your version of the Camunda Platform. e.g., [supported environments for version 7.15](http://docs.camunda.org/7.15/guides/user-guide/#introduction-supported-environments)

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -131,7 +131,7 @@
           <p>In case you get stuck on a problem make sure to <a href="https://forum.camunda.org">ask for Help in the
               Forums</a> or on <a href="http://stackoverflow.com/questions/tagged/camunda">Stack Overflow</a>.</p>
 
-          <p>In case you are an <a href="http://camunda.com/bpm/enterprise/">Enterprise Support</a> customer, create a
+          <p>In case you are an <a href="http://camunda.com/platform-7/editions/">Enterprise Support</a> customer, create a
             support case in Jira.</p>
         </header>
       </section>

--- a/themes/camunda/layouts/shortcodes/enterprise.html
+++ b/themes/camunda/layouts/shortcodes/enterprise.html
@@ -5,7 +5,9 @@
 
   <p>
     Check the <a href="http://camunda.com/bpm/enterprise/">Camunda enterprise homepage</a>
+    Check the <a href="http://camunda.com/platform-7/editions/">Camunda enterprise homepage</a>
     for more information or get your
     <a href="http://camunda.com/bpm/enterprise/trial/">free trial version.</a>
+    <a href="https://camunda.com/download/enterprise/">free trial version.</a>
   </p>
 </div>


### PR DESCRIPTION
Related to changes made in https://github.com/camunda/camunda-docs-manual/pull/1341.