### PR TITLE
experiment: remove noindex tag for a few pages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,6 +9,10 @@ blackfriday:
 
 params:
   canonicalBasePath: "https://docs.camunda.org"
+  skipNoIndexPages:
+    - "/manual/7.17/reference/rest/case-instance/variables/get-variable-binary/"
+    - "/manual/7.17/reference/rest/process-definition/delete-process-definition/"
+    - "/manual/7.17/update/minor/71-to-72/glassfish/"
   sections:
     - id: "get-started"
       name: "Get Started"

--- a/themes/camunda/layouts/partials/header.html
+++ b/themes/camunda/layouts/partials/header.html
@@ -20,10 +20,9 @@
   <meta name="description" content="documentation of the Camunda Platform 7" />
   <meta name="keywords" content="camunda, open source, free, Apache License, Apache 2.0, workflow, BPMN, BPMN 2.0, camunda.org, bpm, BPMS, engine, platform, process, automation, community, documentation" />
   <meta name="author" content="Camunda Platform 7 community" />
-  {{- $skipNoIndexPages := slice "/manual/7.17/reference/rest/case-instance/variables/get-variable-binary/" "/manual/7.17/reference/rest/process-definition/delete-process-definition/" "/manual/7.17/update/minor/71-to-72/glassfish/" }}
   {{ if ($.Site.Params.section.versions)}}
     {{ if (not (eq (index $.Site.Params.section.versions 1) $.Site.Params.section.version))}}
-      {{- if (not (in $skipNoIndexPages .Permalink)) }}
+      {{- if (not (in $.Site.Params.skipNoIndexPages .Permalink)) }}
         <meta name="robots" content="noindex" />
       {{- end }}
     {{ end }}

--- a/themes/camunda/layouts/partials/header.html
+++ b/themes/camunda/layouts/partials/header.html
@@ -20,9 +20,12 @@
   <meta name="description" content="documentation of the Camunda Platform 7" />
   <meta name="keywords" content="camunda, open source, free, Apache License, Apache 2.0, workflow, BPMN, BPMN 2.0, camunda.org, bpm, BPMS, engine, platform, process, automation, community, documentation" />
   <meta name="author" content="Camunda Platform 7 community" />
+  {{- $skipNoIndexPages := slice "/manual/7.17/reference/rest/case-instance/variables/get-variable-binary/" "/manual/7.17/reference/rest/process-definition/delete-process-definition/" "/manual/7.17/update/minor/71-to-72/glassfish/" }}
   {{ if ($.Site.Params.section.versions)}}
     {{ if (not (eq (index $.Site.Params.section.versions 1) $.Site.Params.section.version))}}
-      <meta name="robots" content="noindex" />
+      {{- if (not (in $skipNoIndexPages .Permalink)) }}
+        <meta name="robots" content="noindex" />
+      {{- end }}
     {{ end }}
   {{ end }}
 


### PR DESCRIPTION
Associated with https://github.com/camunda/developer-experience/issues/22. See that issue for a higher level view of all the steps associated with this experiment.

Configures 3 experimental URLs to exclude the `noindex` tag, so that we can see what effect that has on Google's selection of canonical URLs. 

* Google's sees the canonical for each of these 3 pages as the 7.17 version, instead of 7.18.
* All 3 of these pages already include a `link rel=canonical` tag pointing at the 7.18 version.

Once merged & deployed, I'll submit all three pages to Google to reindex. After a period of time (a month or so?), I'll reassess the Google canonical selection for the pages, to see if anything improved.

If things improve for all 3 pages (e.g. Google instead chooses the 7.18 version as canonical), we can talk about how to introduce to a larger experiment set. 

The worst case scenario, as I see it, is that Google will still choose the 7.17 page as canonical, however that page will now be in the search index, and users will get the 7.17 page in their search results instead of no page.

**Note**: I did not add these changes to the theme, as they are temporary, and I only really care if they're in this version right now. If the experiment proves that we want the changes in other versions, I'll start by applying them to the theme.

## Proof that it emits the `noindex` tag for pages other than the 3 in the experiment group

![image](https://user-images.githubusercontent.com/1627089/214436102-36bcd252-77c1-4430-981e-df41039ffe7e.png)

## Proof that it excludes the `noindex` tag for the 3 pages in the experiment group

![image](https://user-images.githubusercontent.com/1627089/214436137-c06b2982-7898-4431-8fd1-6d70bffbf760.png)

![image](https://user-images.githubusercontent.com/1627089/214436161-4a817c5b-e00c-4de1-baae-1ed2730f6f3f.png)

![image](https://user-images.githubusercontent.com/1627089/214436182-656af6e9-e6f8-4c98-a5bf-40c40973eed0.png)

