### PR TITLE
experiment: remove `noindex` tag from 7.15 pages

### DIFF
--- a/themes/camunda/layouts/partials/header.html
+++ b/themes/camunda/layouts/partials/header.html
@@ -20,11 +20,13 @@
   <meta name="description" content="documentation of the Camunda Platform 7" />
   <meta name="keywords" content="camunda, open source, free, Apache License, Apache 2.0, workflow, BPMN, BPMN 2.0, camunda.org, bpm, BPMS, engine, platform, process, automation, community, documentation" />
   <meta name="author" content="Camunda Platform 7 community" />
-  {{ if ($.Site.Params.section.versions)}}
+  <!-- this is temporarily removed for 7.15 as part of an experiment -->
+  <!-- see https://github.com/camunda/developer-experience/issues/22#issuecomment-1444447197 -->
+  <!-- {{ if ($.Site.Params.section.versions)}}
     {{ if (not (eq (index $.Site.Params.section.versions 1) $.Site.Params.section.version))}}
       <meta name="robots" content="noindex" />
     {{ end }}
-  {{ end }}
+  {{ end }} -->
 
   <title>{{ .Title }} | docs.camunda.org</title>
 


### PR DESCRIPTION
This experiment is explained in detail in https://github.com/camunda/developer-experience/issues/22#issuecomment-1444447197.

Removes the `meta noindex` tag from 7.15 pages, to see if this (a) has a positive effect of correcting any incorrectly canonicalized 7.15 pages, and (b) does not have the negative effect of prompting Google to index 7.15 pages instead of 7.18 pages. 

Note that these pages _do_ have a canonical URL pointing at the 7.18 version, which I expect to protect us from Google canonicalizing _and_ indexing these 7.15 pages.

I plan to revisit this before the next product release, and straighten things out at the theme level instead of only in this specific version.

## Proof that it removes the `noindex` tag

<img width="1133" alt="image" src="https://user-images.githubusercontent.com/1627089/221289547-90da7e5d-5067-4368-ad81-330b72348da3.png">
