### PR TITLE
revert 1395 (noindex experiment, v7.17)

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -9,10 +9,6 @@ blackfriday:
 
 params:
   canonicalBasePath: "https://docs.camunda.org"
-  skipNoIndexPages:
-    - "/manual/7.17/reference/rest/case-instance/variables/get-variable-binary/"
-    - "/manual/7.17/reference/rest/process-definition/delete-process-definition/"
-    - "/manual/7.17/update/minor/71-to-72/glassfish/"
   sections:
     - id: "get-started"
       name: "Get Started"

--- a/themes/camunda/layouts/partials/header.html
+++ b/themes/camunda/layouts/partials/header.html
@@ -22,9 +22,7 @@
   <meta name="author" content="Camunda Platform 7 community" />
   {{ if ($.Site.Params.section.versions)}}
     {{ if (not (eq (index $.Site.Params.section.versions 1) $.Site.Params.section.version))}}
-      {{- if (not (in $.Site.Params.skipNoIndexPages .Permalink)) }}
-        <meta name="robots" content="noindex" />
-      {{- end }}
+      <meta name="robots" content="noindex" />
     {{ end }}
   {{ end }}
 


### PR DESCRIPTION
Reverts #1395, which was an experiment to see if removing the `noindex` tag from a few pages had a net positive effect on the SEO/searchability of docs. 

As described in https://github.com/camunda/developer-experience/issues/22#issuecomment-1470772065, this experiment did not have as positive effect as I'd hoped. 