### PR TITLE
Revert 1409 (noindex experiment, v7.15)

### DIFF
--- a/themes/camunda/layouts/partials/header.html
+++ b/themes/camunda/layouts/partials/header.html
@@ -20,13 +20,11 @@
   <meta name="description" content="documentation of the Camunda Platform 7" />
   <meta name="keywords" content="camunda, open source, free, Apache License, Apache 2.0, workflow, BPMN, BPMN 2.0, camunda.org, bpm, BPMS, engine, platform, process, automation, community, documentation" />
   <meta name="author" content="Camunda Platform 7 community" />
-  <!-- this is temporarily removed for 7.15 as part of an experiment -->
-  <!-- see https://github.com/camunda/developer-experience/issues/22#issuecomment-1444447197 -->
-  <!-- {{ if ($.Site.Params.section.versions)}}
+  {{ if ($.Site.Params.section.versions)}}
     {{ if (not (eq (index $.Site.Params.section.versions 1) $.Site.Params.section.version))}}
       <meta name="robots" content="noindex" />
     {{ end }}
-  {{ end }} -->
+  {{ end }}
 
   <title>{{ .Title }} | docs.camunda.org</title>
 


### PR DESCRIPTION
Reverts #1409, which was an experiment to see if removing the `noindex` tag from all 7.15 pages had a net positive effect on the SEO/searchability of docs. 

As described in https://github.com/camunda/developer-experience/issues/22#issuecomment-1470772065, this experiment did not have as positive effect as I'd hoped.