### PR TITLE
Provide a better comment on Identity Provider

### DIFF
--- a/content/update/patch-level.md
+++ b/content/update/patch-level.md
@@ -399,7 +399,7 @@ You can read how to configure the time to live to a smaller interval or restore 
 #### Container-based authentication requires implementing a `ReadOnlyIdentityProvider`
 
 When using [Container-based Authentication]({{< ref "/webapps/shared-options/authentication.md#container-based-authentication" >}}),
-you need to implement the methods `#findUserByQueryCriteria` and `#findGroupByQueryCriteria` of the `ReadOnlyIdentityProvider`.
+you need to make sure that queries for users, groups and tenants are working (not returning `null`) in the `ReadOnlyIdentityProvider`.
 
 This is necessary due to the aforementioned security improvement to revalidate users and groups.
 

--- a/content/update/patch-level.md
+++ b/content/update/patch-level.md
@@ -399,7 +399,7 @@ You can read how to configure the time to live to a smaller interval or restore 
 #### Container-based authentication requires implementing a `ReadOnlyIdentityProvider`
 
 When using [Container-based Authentication]({{< ref "/webapps/shared-options/authentication.md#container-based-authentication" >}}),
-you need to make sure that queries for users, groups and tenants are working (not returning `null`) in the `ReadOnlyIdentityProvider`.
+you need to make sure that queries for users, groups and tenants are working (user can be found, other queries not returning `null`) in the `ReadOnlyIdentityProvider`.
 
 This is necessary due to the aforementioned security improvement to revalidate users and groups.
 

--- a/content/update/patch-level.md
+++ b/content/update/patch-level.md
@@ -398,8 +398,7 @@ You can read how to configure the time to live to a smaller interval or restore 
 
 #### Container-based authentication requires implementing a `ReadOnlyIdentityProvider`
 
-When using [Container-based Authentication]({{< ref "/webapps/shared-options/authentication.md#container-based-authentication" >}}),
-you need to make sure that queries for users, groups and tenants are working (user can be found, other queries not returning `null`) in the `ReadOnlyIdentityProvider`.
+When using [Container-based Authentication]({{< ref "/webapps/shared-options/authentication.md#container-based-authentication" >}}), please provide an implementation for the `ReadOnlyIdentityProvider` interface so that queries return the results of your identity provider.
 
 This is necessary due to the aforementioned security improvement to revalidate users and groups.
 

--- a/content/webapps/shared-options/authentication.md
+++ b/content/webapps/shared-options/authentication.md
@@ -84,7 +84,7 @@ This is what the `web.xml`-based configuration looks like:
 Camunda supports a broad range of containers, including Tomcat, Wildfly, IBM WebSphere and Oracle WebLogic. Using Container-Based Authentication, it is possible to move the authentication action to the container level, which will then make the authentication result available to the Camunda Web Applications.
 
 {{< note title="Heads-up!" class="info" >}}
-Please provide an implementation for the `ReadOnlyIdentityProvider` interface so that queries return the results of your identity provider.
+Please provide an implementation for the `ReadOnlyIdentityProvider` interface so that queries return the results of your identity provider to make **Container-Based Authentication** work.
 {{< /note >}}
 
 ### Enabling Container-Based Authentication

--- a/content/webapps/shared-options/authentication.md
+++ b/content/webapps/shared-options/authentication.md
@@ -84,7 +84,7 @@ This is what the `web.xml`-based configuration looks like:
 Camunda supports a broad range of containers, including Tomcat, Wildfly, IBM WebSphere and Oracle WebLogic. Using Container-Based Authentication, it is possible to move the authentication action to the container level, which will then make the authentication result available to the Camunda Web Applications.
 
 {{< note title="Heads-up!" class="info" >}}
-You need to make sure that queries for users, groups and tenants are working (user can be found, other queries not returning `null`) in the `ReadOnlyIdentityProvider`.
+Please provide an implementation for the `ReadOnlyIdentityProvider` interface so that queries return the results of your identity provider.
 {{< /note >}}
 
 ### Enabling Container-Based Authentication

--- a/content/webapps/shared-options/authentication.md
+++ b/content/webapps/shared-options/authentication.md
@@ -84,8 +84,7 @@ This is what the `web.xml`-based configuration looks like:
 Camunda supports a broad range of containers, including Tomcat, Wildfly, IBM WebSphere and Oracle WebLogic. Using Container-Based Authentication, it is possible to move the authentication action to the container level, which will then make the authentication result available to the Camunda Web Applications.
 
 {{< note title="Heads-up!" class="info" >}}
-You need to implement the methods `#findUserByQueryCriteria` and `#findGroupByQueryCriteria` of the `ReadOnlyIdentityProvider`
-to make **Container-Based Authentication** work.
+You need to make sure that queries for users, groups and tenants are working (user can be found, other queries not returning `null`) in the `ReadOnlyIdentityProvider`.
 {{< /note >}}
 
 ### Enabling Container-Based Authentication


### PR DESCRIPTION
The interface `ReadOnlyIdentityProvider` does not contain the methods `#findUserByQueryCriteria` and `#findGroupByQueryCriteria`. 

The actual requirement for the `AuthenticationUtil` class to function is that 
* the user can be found
* the groups can be queried
* the tenants can be queried

By default, this is already the case. The only known cases where we are facing problems is when the container-based authentication is used to perform SSO.