### PR TITLE
docs(templating): migrate template engines to the community hub

### DIFF
--- a/content/introduction/extensions.md
+++ b/content/introduction/extensions.md
@@ -33,15 +33,3 @@ You can also visit the Camunda Community Hub [community repository](https://gith
 The Camunda Community Hub enables developers to have a centralized home for their Camunda community extensions, and aids new contributors to open source software in discovering new projects to work on.
 
 You can also learn about [contributing code to the core Camunda codebase](https://camunda.com/developers/how-to-contribute/).
-
-# Enterprise Extensions
-
-{{< enterprise >}}
-  Please note that these extensions are only included in the enterprise edition of the Camunda Platform. They are not available in the community edition.
-{{< /enterprise >}}
-
-## XSLT Extension
-
-The XSLT extension depends on the following third-party libraries:
-
-* [SAXON](http://saxon.sourceforge.net/) [(Mozilla Public License 2.0)](https://www.mozilla.org/MPL/2.0/)

--- a/content/update/minor/719-to-720/_index.md
+++ b/content/update/minor/719-to-720/_index.md
@@ -29,6 +29,7 @@ This document guides you through the update from Camunda Platform `7.19.x` to `7
     * For developers: [External Task Client Spring Boot Starter requires JDK 17](#external-task-client-spring-boot-starter-requires-jdk-17)
 12. For developers: [Camunda Platform Run requires JDK 17](#camunda-platform-run-requires-jdk-17)
 13. For developers: [Update Alpine Base Docker Image from version 3.15 to 3.18](#update-alpine-base-of-camunda-docker-images-from-version-3-15-to-3-18)
+14. For developers: [Discontinue support for Velocity, XSLT, and XQuery template engines](#discontinue-support-for-velocity-xslt-and-xquery-template-engines)
 
 This guide covers mandatory migration steps and optional considerations for the initial configuration of new functionality included in Camunda Platform 7.20.
 
@@ -224,3 +225,38 @@ The Camunda Docker images are based on Alpine. This release updates the Alpine b
 [alpine317]: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.17.0
 [alpine318]: https://wiki.alpinelinux.org/wiki/Release_Notes_for_Alpine_3.18.0
 
+# Discontinue support for Velocity, XSLT, and XQuery template engines
+
+We discontinue support for template engines with the following Maven artifacts (groupId:artifactId):
+
+* org.camunda.template-engines:camunda-template-engines-velocity
+* org.camunda.template-engines:camunda-template-engines-xquery
+* org.camunda.bpm.extension.xslt:camunda-bpm-xslt
+
+We moved the source code of the template engines listed above over to Camunda's [Community Hub](https://github.com/camunda-community-hub/camunda-7-template-engines-jsr223) and released version 2.2.0, the first community release and last release triggered by us.
+
+You can contribute to the [GitHub repository](https://github.com/camunda-community-hub/camunda-7-template-engines-jsr223) if you require code changes, library updates, or bug fixes. Camunda doesn't drive development for community extensions.
+
+If you want to continue to use the community-maintained template engines, use the following Maven coordinates:
+
+```xml
+<dependency>
+  <groupId>org.camunda.community.template.engine</groupId>
+  <artifactId>camunda-7-template-engine-velocity</artifactId>
+  <version>2.2.0</version>
+</dependency>
+
+<dependency>
+  <groupId>org.camunda.community.template.engine</groupId>
+  <artifactId>camunda-7-template-engine-xquery</artifactId>
+  <version>2.2.0</version>
+</dependency>
+
+<dependency>
+  <groupId>org.camunda.community.template.engine</groupId>
+  <artifactId>camunda-7-template-engine-xslt</artifactId>
+  <version>2.2.0</version>
+</dependency>
+```
+
+We are looking for maintainers for the template engine extensions. Feel free to reach out to us [via the forum](https://forum.camunda.io/c/camunda-platform-7-topics/39) if you are interested.

--- a/content/user-guide/process-engine/templating.md
+++ b/content/user-guide/process-engine/templating.md
@@ -19,17 +19,17 @@ box:
 
 * [FreeMarker][freemarker]
 
-The following template engine is provided as optional add-on:
+The script engine Freemarker wrapper implementation can be found in the
+[camunda-template-engines-jsr223](https://github.com/camunda/camunda-template-engines-jsr223/) repository.
+
+The following template engines are provided as optional community extensions:
 
 * [Apache Velocity][velocity]
+* [Saxon XQuery](https://www.saxonica.com/html/documentation12/using-xquery/)
+* [Saxon XSLT](https://www.saxonica.com/html/documentation12/using-xsl/)
 
 The script engine wrapper implementations can be found in the
-[camunda-template-engines][camunda-template-engines] repository.
-
-Additionally, the following template engine is supported as enterprise extension:
-
-* [XSLT](/enterprise/download/#additional-information)
-
+[camunda-7-template-engines-jsr223][camunda-7-template-engines-jsr223] community hub repository.
 
 # Install a Template Engine
 
@@ -55,10 +55,30 @@ dependencies must be added as dependencies to the maven `pom.xml` file:
     <artifactId>camunda-template-engines-freemarker</artifactId>
   </dependency>
 
+</dependencies>
+```
+
+Here are the Maven coordinates of the community extensions: 
+
+```xml
+<dependencies>
+
+  <!-- saxon xquery -->
+  <dependency>
+    <groupId>org.camunda.community.template.engine</groupId>
+    <artifactId>camunda-7-template-engine-xquery</artifactId>
+  </dependency>
+
+  <!-- saxon xslt -->
+  <dependency>
+    <groupId>org.camunda.community.template.engine</groupId>
+    <artifactId>camunda-7-template-engine-xslt</artifactId>
+  </dependency>
+
   <!-- apache velocity -->
   <dependency>
-    <groupId>org.camunda.template-engines</groupId>
-    <artifactId>camunda-template-engines-velocity</artifactId>
+    <groupId>org.camunda.community.template.engine</groupId>
+    <artifactId>camunda-7-template-engine-velocity</artifactId>
   </dependency>
 
 </dependencies>
@@ -124,20 +144,7 @@ payload of a `camunda:connector`.
 </bpmn2:serviceTask>
 ```
 
-
 # Use XSLT as Template Engine
-
-{{< enterprise >}}
-  Please note that this feature is only included in the enterprise edition of the Camunda Platform, it is not available in the community edition.
-{{< /enterprise >}}
-
-
-## Install the XSLT Template Engine
-
-The XSLT Template Engine can be downloaded from the [Enterprise Edition Download page](/enterprise/download/#additional-information).
-
-Instructions on how to install the template engine can be found inside the downloaded distribution.
-
 
 ## Use XSLT Template Engine with an embedded process engine
 
@@ -145,17 +152,13 @@ When using an embedded process engine, the XSLT template engine library must be 
 application deployment. When using the process engine in a maven `war` project, the template engine
 dependency must be added as dependencies to the maven `pom.xml` file:
 
-{{< note title="" class="info" >}}
-  Please import the [Camunda BOM](/get-started/apache-maven/) to ensure correct versions for every Camunda project.
-{{< /note >}}
-
 ```xml
 <dependencies>
 
   <!-- XSLT -->
   <dependency>
-    <groupId>org.camunda.bpm.extension.xslt</groupId>
-    <artifactId>camunda-bpm-xslt</artifactId>
+    <groupId>org.camunda.community.template.engine</groupId>
+    <artifactId>camunda-7-template-engine-xslt</artifactId>
   </dependency>
 
 </dependencies>
@@ -191,12 +194,12 @@ Finally, the input of the transformation must be mapped using the special variab
 using a `<camunda:inputParameter ... />` mapping.
 
 A [full example of the XSLT Template Engine][xslt-example] in Camunda Platform can be found in the
-examples repository..
+examples' repository.
 
 
 [freemarker]: http://freemarker.org/
 [velocity]: http://velocity.apache.org/
-[camunda-template-engines]: https://github.com/camunda/camunda-template-engines-jsr223
+[camunda-7-template-engines-jsr223]: https://github.com/camunda-community-hub/camunda-7-template-engines-jsr223
 [use-scripts]: {{< ref "/user-guide/process-engine/scripting.md" >}}
 [script-source]: {{< ref "/user-guide/process-engine/scripting.md#script-source" >}}
 [xslt-example]: https://github.com/camunda/camunda-bpm-examples/tree/master/scripttask/xslt-scripttask

--- a/content/user-guide/process-engine/templating.md
+++ b/content/user-guide/process-engine/templating.md
@@ -43,7 +43,8 @@ application deployment. When using the process engine in a maven `war` project, 
 dependencies must be added as dependencies to the maven `pom.xml` file:
 
 {{< note title="" class="info" >}}
-  Please import the [Camunda BOM](/get-started/apache-maven/) to ensure correct versions for every Camunda project.
+  The [Camunda BOM](/get-started/apache-maven/) only contains the officially supported freemarker template engine.
+  For the community-driven template engines, please check the Maven coordinates below. 
 {{< /note >}}
 
 ```xml


### PR DESCRIPTION
The following template engines wrapper were moved to the community hub:

* Saxon XSLT
* Saxon XQuery
* Apache Velocity

related to camunda/camunda-bpm-platform#3695, camunda/camunda-bpm-platform#3696, camunda/camunda-bpm-platform#3697