### PR TITLE
docs(mig): container-based auth needs `ReadOnlyIdentityProvider` impl

### DIFF
--- a/content/update/patch-level.md
+++ b/content/update/patch-level.md
@@ -396,6 +396,12 @@ This new default might lead to a higher load on your database.
 
 You can read how to configure the time to live to a smaller interval or restore the legacy behavior (disable the authentication cache time to live) in the documentation about [Web Applications]({{< ref "/webapps/shared-options/authentication.md#time-to-live" >}}).
 
+#### Container-based authentication requires implementing a `ReadOnlyIdentityProvider`
+
+When using [Container-based Authentication]({{< ref "/webapps/shared-options/authentication.md#container-based-authentication" >}}), please provide an implementation for the `ReadOnlyIdentityProvider` interface so that queries return the results of your identity provider.
+
+This is necessary due to the aforementioned security improvement to revalidate users and groups.
+
 ## 7.18.6 to 7.18.7
 
 ### Optimistic Locking on PostgreSQL

--- a/content/webapps/shared-options/authentication.md
+++ b/content/webapps/shared-options/authentication.md
@@ -83,6 +83,10 @@ This is what the `web.xml`-based configuration looks like:
 
 Camunda supports a broad range of containers, including Tomcat, Wildfly, IBM WebSphere and Oracle WebLogic. Using Container-Based Authentication, it is possible to move the authentication action to the container level, which will then make the authentication result available to the Camunda Web Applications.
 
+{{< note title="Heads-up!" class="info" >}}
+Please provide an implementation for the `ReadOnlyIdentityProvider` interface so that queries return the results of your identity provider to make **Container-Based Authentication** work.
+{{< /note >}}
+
 ### Enabling Container-Based Authentication
 
 The Container-Based Authentication implementation for the Web Applications is switched off by default, but can be activated by adding a servlet filter in the `web.xml` as follows:


### PR DESCRIPTION
related to camunda/camunda-bpm-platform#3732