### PR TITLE
chore(upgrade): add builtin task listener change to migration guide

### DIFF
--- a/content/update/minor/720-to-721/_index.md
+++ b/content/update/minor/720-to-721/_index.md
@@ -20,6 +20,7 @@ This document guides you through the update from Camunda Platform `7.20.x` to `7
 1. For developers: [Add Default History Time To Live to BPMN Fluent API](#add-default-history-time-to-live-to-bpmn-fluent-api)
 1. For administrators: [Spring Boot Starter and Run logs admin user information on `DEBUG` level](#spring-boot-starter-and-run-logs-admin-user-information-on-debug-level)
 1. For developers: [Update Java External Task Client's Apache HttpClient to version 5](#update-java-external-task-client-s-apache-httpclient-to-version-5)
+1. For developers: [Changed trigger order of built-in task listeners](#changed-trigger-order-of-built-in-task-listeners)
 
 This guide covers mandatory migration steps and optional considerations for the initial configuration of new functionality included in Camunda Platform 7.21.
 
@@ -70,3 +71,11 @@ This means an update to this version requires code and configuration adjustments
 [HttpCore52]: https://hc.apache.org/httpcomponents-core-5.2.x/index.html
 [HttpClient53]: https://hc.apache.org/httpcomponents-client-5.3.x/index.html
 [HttpClient53-migration]: https://hc.apache.org/httpcomponents-client-5.3.x/migration-guide/index.html
+
+# Changed trigger order of built-in task listeners
+
+Built-in task listeners are used internally by the engine and not intended to be used by the user. User-defined task listeners are handled separately. For both, regular process execution and process instance modification, the engine ensures the following:
+
+* Built-in task listeners are executed before user-defined task listeners.
+* Built-in task listeners are executed in the order in which they were registered.
+* User-defined task listeners are executed in the order in which they were registered (unchanged).

--- a/content/update/patch-level.md
+++ b/content/update/patch-level.md
@@ -464,6 +464,16 @@ The Camunda Docker images are based on Alpine. This release updates the Alpine b
 In previous releases, when configuring Camunda's admin user in the Spring Boot Starter and Run via `camunda.bpm.admin-user`, information about the admin user appeared in the logs on log level `INFO` on startup.
 With this release, the log level for the logs `STARTER-SB010` and `STARTER-SB011` was changed to `DEBUG`.
 
+## 7.20.2 to 7.20.3
+
+### Changed trigger order of built-in task listeners
+
+Built-in task listeners are used internally by the engine and not intended to be used by the user. User-defined task listeners are handled separately. For both, regular process execution and process instance modification, the engine ensures the following:
+
+* Built-in task listeners are executed before user-defined task listeners.
+* Built-in task listeners are executed in the order in which they were registered.
+* User-defined task listeners are executed in the order in which they were registered (unchanged).
+
 # Full Distribution
 
 This section is applicable if you installed the [Full Distribution]({{< ref "/introduction/downloading-camunda.md#full-distribution" >}}) with a **shared process engine**. In this case you need to update the libraries and applications installed inside the application server.


### PR DESCRIPTION
Related to https://github.com/camunda/camunda-bpm-platform/issues/4042