### PR TITLE
chore(quarkus-integration): Extend Quarkus Compatibility

### DIFF
--- a/content/user-guide/quarkus-integration/version-compatibility.md
+++ b/content/user-guide/quarkus-integration/version-compatibility.md
@@ -36,8 +36,8 @@ Only these default combinations are recommended (and supported) by Camunda.
     <td>3.2.x.Final</td>
   </tr>
   <tr>
-    <td>7.21.x</td>
-    <td>3.8.x.Final</td>
+    <td>7.21.0-alpha3</td>
+    <td>3.7.x</td>
   </tr>
 </table>
 

--- a/content/user-guide/quarkus-integration/version-compatibility.md
+++ b/content/user-guide/quarkus-integration/version-compatibility.md
@@ -35,6 +35,10 @@ Only these default combinations are recommended (and supported) by Camunda.
     <td>7.20.x</td>
     <td>3.2.x.Final</td>
   </tr>
+  <tr>
+    <td>7.21.x</td>
+    <td>3.8.x.Final</td>
+  </tr>
 </table>
 
 In case a certain Quarkus version has a bug, you can override the existing Quarkus version by adding the following

--- a/content/user-guide/quarkus-integration/version-compatibility.md
+++ b/content/user-guide/quarkus-integration/version-compatibility.md
@@ -36,7 +36,7 @@ Only these default combinations are recommended (and supported) by Camunda.
     <td>3.2.x.Final</td>
   </tr>
   <tr>
-    <td>7.21.0-alpha3</td>
+    <td>7.21.0</td>
     <td>3.7.x</td>
   </tr>
 </table>


### PR DESCRIPTION
- camunda 7.21.x with Quarkus 3.8.x

Related-to: https://github.com/camunda/camunda-bpm-platform/pull/3785