### PR TITLE
chore(quarkus-integration): Extend Quarkus Compatibility to 3.8

### DIFF
--- a/content/user-guide/quarkus-integration/version-compatibility.md
+++ b/content/user-guide/quarkus-integration/version-compatibility.md
@@ -37,7 +37,7 @@ Only these default combinations are recommended (and supported) by Camunda.
   </tr>
   <tr>
     <td>7.21.0</td>
-    <td>3.7.x</td>
+    <td>3.8.x</td>
   </tr>
 </table>
 

--- a/content/user-guide/quarkus-integration/version-compatibility.md
+++ b/content/user-guide/quarkus-integration/version-compatibility.md
@@ -36,7 +36,7 @@ Only these default combinations are recommended (and supported) by Camunda.
     <td>3.2.x.Final</td>
   </tr>
   <tr>
-    <td>7.21.0</td>
+    <td>7.21.x</td>
     <td>3.8.x</td>
   </tr>
 </table>


### PR DESCRIPTION
Add Quarkus 3.8 Support to Documentation

Related-to: https://github.com/camunda/camunda-bpm-platform/issues/3785