### PR TITLE
docs: Switching from Nexus to Artifactory

### DIFF
--- a/content/installation/database-schema.md
+++ b/content/installation/database-schema.md
@@ -42,7 +42,7 @@ The [update](#update) paragraph provides more details on this topic.
 
 Camunda 7 comes with a maintained changelog file that Liquibase can consume.
 This changelog defines which SQL statements to execute on a database.
-You can find the changelog and its referenced resources on our [Nexus].
+You can find the changelog and its referenced resources on our [Artifactory].
 Select the respective version (`$PLATFORM_VERSION`) and download the resources as a `zip` or `tar.gz` file.
 Open the `camunda-sql-scripts-$PLATFORM_VERSION/liquibase` folder to find the changelog. 
 In case you are using a [pre-packaged distribution], the Liquibase resources already reside in the `sql/liquibase` folder of the distribution.
@@ -76,7 +76,7 @@ Furthermore, if you have defined a specific prefix for the entities of your data
 ## Manual installation
 
 To install the database schema required for Camunda 7, we provide a set of scripts with prepared DDL statements.
-Those scripts create all required tables and default indices. You can find the provided SQL scripts on our [Nexus]. 
+Those scripts create all required tables and default indices. You can find the provided SQL scripts on our [Artifactory]. 
 Select the respective version (`$PLATFORM_VERSION`) and download the scripts as a `zip` or `tar.gz` file.
 Open the `camunda-sql-scripts-$PLATFORM_VERSION/create` folder to find all available scripts. 
 In case you are using a [pre-packaged distribution], the SQL scripts already reside in the `sql/create` folder of the distribution.
@@ -117,7 +117,7 @@ Based on that changelog and the tracking tables, Liquibase determines which chan
 
 Perform the following steps to update the database schema on your database instance:
 
-1. Select the respective version you want to update to (`$Y`) on our [Nexus] and download the resources as a `zip` or `tar.gz` file.
+1. Select the respective version you want to update to (`$Y`) on our [Artifactory] and download the resources as a `zip` or `tar.gz` file.
 Open the `camunda-sql-scripts-$Y/liquibase` folder to find the changelog file.
 In case you are using a [pre-packaged distribution], the Liquibase resources already reside in the `sql/liquibase` folder of the distribution with version `$Y`.
 1. Run Liquibase's [update command](https://docs.liquibase.com/commands/community/update.html) referencing the new `camunda-changelog.xml` of version `$Y`.
@@ -159,7 +159,7 @@ Updating from your current minor version (`$X`) to its follow-up version (`$Y`) 
 Follow the outlined procedure to perform this update:
 
 1. Check for [available database patch scripts](#patch-level-update") for your database that are within the bounds of your update path.
-You can find the scripts on our [Nexus].
+You can find the scripts on our [Artifactory].
 Select the respective version you want to update to (`$Y`) and download the scripts as a `zip` or `tar.gz` file.
 Open the `camunda-sql-scripts-$Y/upgrade` folder to find all available scripts. 
 In case you are using a [pre-packaged distribution], the SQL scripts already reside in the `sql/upgrade` folder of the distribution with version `$Y`.
@@ -623,7 +623,7 @@ Therefore, the procedure for patch-level updates is equivalent to that for [mino
 
 ### Manual patch level update
 
-You can find the necessary scripts on our [Nexus].
+You can find the necessary scripts on our [Artifactory].
 Select the respective patch version you want to update to (`$Y`) and download the scripts as a `zip` or `tar.gz` file.
 Open the `camunda-sql-scripts-$Y/upgrade` folder to find all available patch scripts.
 In case you are using a [pre-packaged distribution], the SQL scripts reside in the `sql/upgrade` folder of the distribution you want to update to.
@@ -633,5 +633,5 @@ If you do choose to apply a database patch, then you must apply all patch script
 
 <strong>Note:</strong> Some patches are provided for multiple versions. It is not required to execute them more than once. See the description of the [patch version list](#patch-level-update) for information on duplicate fixes.
 
-[Nexus]: https://artifacts.camunda.com/artifactory/camunda-bpm/org/camunda/bpm/distro/camunda-sql-scripts/
+[Artifactory]: https://artifacts.camunda.com/artifactory/camunda-bpm/org/camunda/bpm/distro/camunda-sql-scripts/
 [pre-packaged distribution]: {{< ref "/introduction/downloading-camunda.md#full-distribution" >}}

--- a/content/installation/full/tomcat/manual.md
+++ b/content/installation/full/tomcat/manual.md
@@ -158,7 +158,7 @@ This section describes how to install optional Camunda 7 dependencies onto a Tom
 
 The following steps are required to deploy the applications:
 
-1. Download the Camunda 7 web application that contains both applications from our [Maven Nexus Server](https://artifacts.camunda.com/artifactory/camunda-bpm/org/camunda/bpm/webapp/camunda-webapp-tomcat/).
+1. Download the Camunda 7 web application that contains both applications from our [Maven Artifactory Server](https://artifacts.camunda.com/artifactory/camunda-bpm/org/camunda/bpm/webapp/camunda-webapp-tomcat/).
    Or switch to the private repository for the enterprise version (User and password from license required).
    Choose the correct version named `$PLATFORM_VERSION/camunda-webapp-tomcat-$PLATFORM_VERSION.war`.
 2. Copy the war file to `$TOMCAT_HOME/webapps/camunda.war`.
@@ -171,7 +171,7 @@ The following steps are required to deploy the applications:
 
 The following steps are required to deploy the REST API:
 
-1. Download the REST API web application archive from our [Maven Nexus Server](https://artifacts.camunda.com/artifactory/camunda-bpm/org/camunda/bpm/camunda-engine-rest/).
+1. Download the REST API web application archive from our [Maven Artifactory Server](https://artifacts.camunda.com/artifactory/camunda-bpm/org/camunda/bpm/camunda-engine-rest/).
     Or switch to the private repository for the enterprise version (User and password from license required).
     Choose the correct version named `$PLATFORM_VERSION/camunda-engine-rest-$PLATFORM_VERSION-tomcat.war`.
 2. Copy the war file to `$TOMCAT_HOME/webapps`.


### PR DESCRIPTION
# Description

Switch from Nexus to Artifactory in documentation as noted in https://camunda.com/blog/2022/03/a-new-domain-name-for-camunda-artifactory/:

> We’ve officially started using Artifactory, the universal repository manager by JFrog, as a tool to replace Nexus for storing maven artifacts and distributing them to Camunda users and team members. 


## GitHub Issue
Currently is not linked to GitHub issue (does not appear to be an issues tab visible to public in this docs repo)