### PR TITLE
Update http-connector.md for  Camunda HTTP Connector enhancement for 4XX and 5XX errors -GIT Issue 4241

### DIFF
--- a/content/reference/connect/http-connector.md
+++ b/content/reference/connect/http-connector.md
@@ -109,12 +109,10 @@ HttpResponse response = http.createRequest()
   .execute();
 ```
 
-## Enabling HTTP Error Handling
+## Enabling HTTP Response Error Handling
 
-<strong>Note:</strong> HTTP Connector does not seamlessly handle 4XX and 5XX related response errors during HTTP call.
-Custom scripts within workflows have to be employed to handle these errors.To support handling of 
-these errors without additional scripting set `throw-http-error` property to `TRUE` via `configOption`
-method.
+By default, the HTTP connector does not seamlessly handle 4XX and 5XX related response errors during HTTP call.
+To activate the handling of these errors without additional scripting, set the `throw-http-error` property to `TRUE` via the `configOption` method. Once enabled, the client will throw an exception in case of http response errors (status code 400-599).
 
 ```java
 HttpResponse response = http.createRequest()

--- a/content/reference/connect/http-connector.md
+++ b/content/reference/connect/http-connector.md
@@ -109,6 +109,21 @@ HttpResponse response = http.createRequest()
   .execute();
 ```
 
+## Enabling HTTP Error Handling
+
+<strong>Note:</strong> HTTP Connector does not seamlessly handle 4XX and 5XX related response errors during HTTP call.
+Custom scripts within workflows have to be employed to handle these errors.To support handling of 
+these errors without additional scripting set `throw-http-error` property to `TRUE` via `configOption`
+method.
+
+```java
+HttpResponse response = http.createRequest()
+  .get()
+  .configOption("throw-http-error", "TRUE")
+  .url("http://camunda.org")
+  .execute();
+```
+
 ## Using the Generic API
 
 Besides the configuration methods also a generic API exists to


### PR DESCRIPTION
added documentation updates for http-connector error handling enhancement git issue : https://github.com/camunda/camunda-bpm-platform/issues/4241

Change Description:
Current HTTP connector does not throw an error for 4XX and 5XX errors
The errors need to be explicitly handled by the modeler through an inline script.
Since this code of handling HTTP response is repeatable and reusable, it would be good to modify default behavior of http connector to throw a bpmnError in case of API call failures so that modeler can handle them as desired.
This has been made configurable through an engine setting by adding a new flag called throw-http-error. By default, this flag would be false, where modeler would have to explicitly handle such Errors. If marked true, then the feature that is being built to handle such errors should be enabled.