### PR TITLE
chore(patch): upgrade note about jmx

### DIFF
--- a/content/update/minor/70-to-71/_index.md
+++ b/content/update/minor/70-to-71/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.0 to 7.1"
-weight: 120
+weight: 25
 layout: "single"
 
 menu:

--- a/content/update/minor/71-to-72/_index.md
+++ b/content/update/minor/71-to-72/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.1 to 7.2"
-weight: 110
+weight: 24
 layout: "single"
 
 menu:

--- a/content/update/minor/710-to-711/_index.md
+++ b/content/update/minor/710-to-711/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.10 to 7.11"
-weight: 42
+weight: 14
 layout: "single"
 
 menu:

--- a/content/update/minor/711-to-712/_index.md
+++ b/content/update/minor/711-to-712/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.11 to 7.12"
-weight: 30
+weight: 13
 layout: "single"
 
 menu:

--- a/content/update/minor/712-to-713/_index.md
+++ b/content/update/minor/712-to-713/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.12 to 7.13"
-weight: 20
+weight: 12
 layout: "single"
 
 menu:

--- a/content/update/minor/713-to-714/_index.md
+++ b/content/update/minor/713-to-714/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.13 to 7.14"
-weight: 10
+weight: 11
 layout: "single"
 
 menu:

--- a/content/update/minor/714-to-715/_index.md
+++ b/content/update/minor/714-to-715/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.14 to 7.15"
-weight: 9
+weight: 10
 layout: "single"
 
 menu:

--- a/content/update/minor/715-to-716/_index.md
+++ b/content/update/minor/715-to-716/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.15 to 7.16"
-weight: 8
+weight: 9
 layout: "single"
 
 menu:

--- a/content/update/minor/716-to-717/_index.md
+++ b/content/update/minor/716-to-717/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.16 to 7.17"
-weight: 7
+weight: 8
 layout: "single"
 
 menu:

--- a/content/update/minor/717-to-718/_index.md
+++ b/content/update/minor/717-to-718/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.17 to 7.18"
-weight: 6
+weight: 7
 layout: "single"
 
 menu:

--- a/content/update/minor/718-to-719/_index.md
+++ b/content/update/minor/718-to-719/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.18 to 7.19"
-weight: 5
+weight: 6
 layout: "single"
 
 menu:

--- a/content/update/minor/719-to-720/_index.md
+++ b/content/update/minor/719-to-720/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.19 to 7.20"
-weight: 4
+weight: 5
 layout: "single"
 
 menu:

--- a/content/update/minor/72-to-73/_index.md
+++ b/content/update/minor/72-to-73/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.2 to 7.3"
-weight: 100
+weight: 23
 layout: "single"
 
 menu:

--- a/content/update/minor/720-to-721/_index.md
+++ b/content/update/minor/720-to-721/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.20 to 7.21"
-weight: 3
+weight: 4
 layout: "single"
 
 menu:

--- a/content/update/minor/721-to-722/_index.md
+++ b/content/update/minor/721-to-722/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.21 to 7.22"
-weight: 2
+weight: 3
 layout: "single"
 
 menu:

--- a/content/update/minor/722-to-723/_index.md
+++ b/content/update/minor/722-to-723/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.22 to 7.23"
-weight: 1
+weight: 2
 layout: "single"
 
 menu:

--- a/content/update/minor/723-to-724/_index.md
+++ b/content/update/minor/723-to-724/_index.md
@@ -15,7 +15,9 @@ menu:
 
 This document guides you through the update from Camunda `7.23.x` to `7.24.0` and covers the following use cases:
 
-1. For administrators and developers: [JMX Prometheus Javaagent Update](#jmx-prometheus-javaagent-upgrade)
+1. For administrators and developers: [Database updates](#database-updates)
+1. For administrators and developers: [Full distribution update](#full-distribution)
+2. For administrators and developers: [JMX Prometheus Javaagent Update](#jmx-prometheus-javaagent-upgrade)
 
 This guide covers mandatory migration steps and optional considerations for the initial configuration of new functionality included in Camunda 7.24.
 

--- a/content/update/minor/723-to-724/_index.md
+++ b/content/update/minor/723-to-724/_index.md
@@ -1,0 +1,43 @@
+---
+
+title: "Update from 7.23 to 7.24"
+weight: 1
+layout: "single"
+
+menu:
+  main:
+    name: "7.23 to 7.24"
+    identifier: "migration-guide-724"
+    parent: "migration-guide-minor"
+    pre: "Update from `7.23.x` to `7.24.0`."
+
+---
+
+This document guides you through the update from Camunda `7.23.x` to `7.24.0` and covers the following use cases:
+
+1. For administrators and developers: [JMX Prometheus Javaagent Update](#jmx-prometheus-javaagent-upgrade)
+
+This guide covers mandatory migration steps and optional considerations for the initial configuration of new functionality included in Camunda 7.24.
+
+# Database updates
+
+Every Camunda installation requires a database schema update. Check our [database schema update guide]({{< ref "/installation/database-schema.md#update" >}})
+for further instructions.
+
+# Full distribution
+
+This section is applicable if you installed the
+[Full Distribution]({{< ref "/introduction/downloading-camunda.md#full-distribution" >}})
+with a **shared process engine**.
+
+The following steps are required:
+
+1. Update the Camunda libraries and applications inside the application server.
+2. Migrate custom process applications.
+
+Before starting, ensure you have downloaded the Camunda 7.24 distribution for the application server you use. This contains the SQL scripts and libraries required for the update. This guide assumes you have unpacked the distribution to a path named `$DISTRIBUTION_PATH`.
+
+# JMX Prometheus Javaagent Upgrade
+
+This minor upgrades the JMX Prometheus Javaagent used in the Camunda docker image to version 1.0.1.
+For a complete list of changes for this upgrade, please refer to the [JMX Prometheus release notes](https://github.com/prometheus/jmx_exporter/releases/tag/1.0.1).

--- a/content/update/minor/73-to-74/_index.md
+++ b/content/update/minor/73-to-74/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.3 to 7.4"
-weight: 90
+weight: 22
 layout: "single"
 
 menu:

--- a/content/update/minor/74-to-75/_index.md
+++ b/content/update/minor/74-to-75/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.4 to 7.5"
-weight: 80
+weight: 21
 layout: "single"
 
 menu:

--- a/content/update/minor/75-to-76/_index.md
+++ b/content/update/minor/75-to-76/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.5 to 7.6"
-weight: 70
+weight: 20
 layout: "single"
 
 menu:

--- a/content/update/minor/76-to-77/_index.md
+++ b/content/update/minor/76-to-77/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.6 to 7.7"
-weight: 60
+weight: 19
 layout: "single"
 
 menu:

--- a/content/update/minor/77-to-78/_index.md
+++ b/content/update/minor/77-to-78/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.7 to 7.8"
-weight: 55
+weight: 18
 layout: "single"
 
 menu:

--- a/content/update/minor/78-to-79/_index.md
+++ b/content/update/minor/78-to-79/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.8 to 7.9"
-weight: 50
+weight: 17
 layout: "single"
 
 menu:

--- a/content/update/minor/79-to-710/_index.md
+++ b/content/update/minor/79-to-710/_index.md
@@ -1,7 +1,7 @@
 ---
 
 title: "Update from 7.9 to 7.10"
-weight: 47
+weight: 16
 layout: "single"
 
 menu:


### PR DESCRIPTION
related to[ #4962](https://github.com/camunda/camunda-bpm-platform/issues/4962)

Adds a note about the JMX update upgrade notes. 
Only merge once PR in the docker repo is merged.

Question for reviewer:
It looks to me like the patch notes for a specific minor are backported to that minor, so these would go on master and 7.23. Is that correct?